### PR TITLE
Revert "Allow omitting job arguments..."

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -251,7 +251,7 @@ queue.prototype.allWorkingOn = function(callback){
   var results = {};
   var counter = 0;
   self.workers(function(err, workers){
-    if(err && typeof callback === 'function'){
+    if(err && typeof callback === 'function'){ 
       callback(err);
     }else if(!workers || hashLength(workers) === 0){
       callback(null, results);
@@ -261,12 +261,12 @@ queue.prototype.allWorkingOn = function(callback){
         results[w] = 'started';
         self.workingOn(w, workers[w], function(err, data){
           counter--;
-          if(data){
+          if(data){ 
             data = JSON.parse(data);
-            results[data.worker] = data;
+            results[data.worker] = data; 
           }
           if(counter === 0 && typeof callback === 'function'){
-            callback(err, results);
+            callback(err, results); 
           }
         });
       };
@@ -282,7 +282,7 @@ var arrayify = function(o){
   if( Array.isArray(o) ) {
     return o;
   }else{
-    return !!o ? [o] : [];
+    return [o];
   }
 }
 

--- a/test/core/worker.js
+++ b/test/core/worker.js
@@ -57,7 +57,7 @@ describe('worker', function(){
 
     resolved = false;
     worker = new specHelper.NR.worker({connection: connectionDetails, timeout: specHelper.timeout}, jobs, function(err){
-      if(resolved === false){ // new versions of redis will keep retrying in node v0.11x...
+      if(resolved === false){ // new versions of redis will keep retrying in node v0.11x... 
         should.exist(err);
         resolved = true;
         done();
@@ -167,17 +167,6 @@ describe('worker', function(){
         worker.start();
       });
 
-      it('allows omitting arguments for jobs that dont have any', function(done){
-        var listener = worker.on('success', function(q, job, result){
-          result.should.equal("ok");
-
-          worker.removeAllListeners('success');
-          done();
-        });
-
-        queue.enqueue(specHelper.queue, "quickDefine");
-        worker.start();
-      });
 
       it('will not work jobs that are not defined', function(done){
         var listener = worker.on('failure', function(q, job, failure){


### PR DESCRIPTION
This does not handle correctly falsy values. E.g. passing false or 0 as argument should still be converted to array as [false] and [0].

I will make better solution to check if argument parameter was actually given or not when enqueuing. Maybe check the arguments length or something. 