### PR TITLE
Add support for omitting args when using enqueuing methods

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -200,14 +200,18 @@ queue.prototype.allDelayed = function(callback){
   var started = 0;
   var results = {};
   self.timestamps(function(err, timestamps){
-    timestamps.forEach(function(timestamp){
-      started++;
-      self.delayedAt(timestamp, function(err, tasks, rTimestamp){
-        results[(rTimestamp * 1000)] = tasks;
-        started--;
-        if(started === 0){ callback(err, results) }
+    if(timestamps.length === 0){
+      callback(err, {})
+    }else{
+      timestamps.forEach(function(timestamp){
+        started++;
+        self.delayedAt(timestamp, function(err, tasks, rTimestamp){
+          results[(rTimestamp * 1000)] = tasks;
+          started--;
+          if(started === 0){ callback(err, results) }
+        });
       });
-    });
+    }
   });
 }
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -39,6 +39,12 @@ queue.prototype.encode = function(q, func, args){
 
 queue.prototype.enqueue = function(q, func, args, callback){
   var self = this;
+  if(arguments.length === 3 && typeof args === 'function'){
+    callback = args;
+    args = [];
+  }else if(arguments.length < 3){
+    args = [];
+  }
   var args = arrayify(args);
   var job = self.jobs[func];
   self.runPlugins('before_enqueue', func, q, job, args, function(err, toRun){
@@ -61,6 +67,12 @@ queue.prototype.enqueue = function(q, func, args, callback){
 queue.prototype.enqueueAt = function(timestamp, q, func, args, callback){
   // Don't run plugins here, they should be run by scheduler at the enqueue step
   var self = this;
+  if(arguments.length === 4 && typeof args === 'function'){
+    callback = args;
+    args = [];
+  }else if(arguments.length < 4){
+    args = [];
+  }
   var args = arrayify(args);
   self.connection.ensureConnected(callback, function(){
     var item = self.encode(q, func, args);
@@ -80,6 +92,12 @@ queue.prototype.enqueueAt = function(timestamp, q, func, args, callback){
 
 queue.prototype.enqueueIn = function(time, q, func, args, callback){
   var self = this;
+  if(arguments.length === 4 && typeof args === 'function'){
+    callback = args;
+    args = [];
+  }else if(arguments.length < 4){
+    args = [];
+  }
   var args = arrayify(args);
   var timestamp = (new Date().getTime()) + time;
   self.enqueueAt(timestamp, q, func, args, function(){
@@ -114,11 +132,20 @@ queue.prototype.length = function(q, callback){
 
 queue.prototype.del = function(q, func, args, count, callback){
   var self = this;
-  var args = arrayify(args);
-  if(typeof count == 'function' && callback == null){
+  if(arguments.length === 4 && typeof count == 'function'){
     callback = count;
-    count = 0; // remove first enqueued items that match
+    count = 0;
+  }else if(arguments.length === 3){
+    if(typeof args == 'function'){
+      callback = args;
+      args = [];
+    }
+    count = 0;
+  }else if(arguments.length < 3){
+    args = [];
+    count = 0;
   }
+  var args = arrayify(args);
   self.connection.ensureConnected(callback, function(){
     self.connection.redis.lrem(self.connection.key('queue', q), count, self.encode(q, func, args), function(err, count){
       if(typeof callback === 'function'){ callback(err, count); }
@@ -128,6 +155,12 @@ queue.prototype.del = function(q, func, args, count, callback){
 
 queue.prototype.delDelayed = function(q, func, args, callback){
   var self = this;
+  if(arguments.length === 3 && typeof args === 'function'){
+    callback = args;
+    args = [];
+  }else if(arguments.length < 3){
+    args = [];
+  }
   var args = arrayify(args);
   var search = self.encode(q, func, args);
   self.connection.ensureConnected(callback, function(){
@@ -155,6 +188,12 @@ queue.prototype.delDelayed = function(q, func, args, callback){
 
 queue.prototype.scheduledAt = function(q, func, args, callback){
   var self = this;
+  if(arguments.length === 3 && typeof args === 'function'){
+    callback = args;
+    args = [];
+  }else if(arguments.length < 3){
+    args = [];
+  }
   var args = arrayify(args);
   var search = self.encode(q, func, args);
   self.connection.ensureConnected(callback, function(){
@@ -255,7 +294,7 @@ queue.prototype.allWorkingOn = function(callback){
   var results = {};
   var counter = 0;
   self.workers(function(err, workers){
-    if(err && typeof callback === 'function'){ 
+    if(err && typeof callback === 'function'){
       callback(err);
     }else if(!workers || hashLength(workers) === 0){
       callback(null, results);
@@ -265,12 +304,12 @@ queue.prototype.allWorkingOn = function(callback){
         results[w] = 'started';
         self.workingOn(w, workers[w], function(err, data){
           counter--;
-          if(data){ 
+          if(data){
             data = JSON.parse(data);
-            results[data.worker] = data; 
+            results[data.worker] = data;
           }
           if(counter === 0 && typeof callback === 'function'){
-            callback(err, results); 
+            callback(err, results);
           }
         });
       };
@@ -283,7 +322,7 @@ queue.prototype.allWorkingOn = function(callback){
 /////////////
 
 var arrayify = function(o){
-  if( Array.isArray(o) ) {
+  if(Array.isArray(o)){
     return o;
   }else{
     return [o];

--- a/test/core/queue.js
+++ b/test/core/queue.js
@@ -66,7 +66,7 @@ describe('queue', function(){
           should.exist(obj);
           obj = JSON.parse(obj);
           obj['class'].should.equal('someJob');
-          // obj['args'].should.equal([1,2,3]);
+          obj['args'].should.eql([1,2,3]);
           done();
         });
       });
@@ -80,7 +80,7 @@ describe('queue', function(){
             should.exist(obj);
             obj = JSON.parse(obj);
             obj['class'].should.equal('someJob');
-            // obj['args'].should.equal([1,2,3]);
+            obj['args'].should.eql([1,2,3]);
             done();
           });
         });
@@ -96,7 +96,7 @@ describe('queue', function(){
             should.exist(obj);
             obj = JSON.parse(obj);
             obj['class'].should.equal('someJob');
-            // obj['args'].should.equal([1,2,3]);
+            obj['args'].should.eql([1,2,3]);
             done();
           });
         });

--- a/test/core/queue.js
+++ b/test/core/queue.js
@@ -157,6 +157,15 @@ describe('queue', function(){
       });
     });
 
+    it('can handle single arguments without explicit array', function(done){
+      queue.enqueue(specHelper.queue, 'someJob', 1, function(){
+        specHelper.popFromQueue(function(err, obj){
+          JSON.parse(obj)['args'].should.eql([1]);
+          done();
+        });
+      });
+    });
+
     it('allows omitting arguments when enqueuing', function(done){
       queue.enqueue(specHelper.queue, 'noParams'); // no callback here, but in practice will finish before next enqueue calls back
       queue.enqueue(specHelper.queue, 'noParams', function(){

--- a/test/core/scheduler.js
+++ b/test/core/scheduler.js
@@ -31,7 +31,7 @@ describe('scheduler', function(){
 
     var resolved = false;
     scheduler = new specHelper.NR.scheduler({connection: connectionDetails, timeout: specHelper.timeout}, function(err){
-      if(resolved === false){ // new versions of redis will keep retrying in node v0.11x... 
+      if(resolved === false){ // new versions of redis will keep retrying in node v0.11x...
         should.exist(err);
         resolved = true;
         done();
@@ -81,7 +81,7 @@ describe('scheduler', function(){
             should.exist(obj);
             obj = JSON.parse(obj);
             obj['class'].should.equal('someJob');
-            // obj['args'].should.equal([1,2,3]);
+            obj['args'].should.eql([1,2,3]);
             done();
           });
         });

--- a/test/core/worker.js
+++ b/test/core/worker.js
@@ -57,7 +57,7 @@ describe('worker', function(){
 
     resolved = false;
     worker = new specHelper.NR.worker({connection: connectionDetails, timeout: specHelper.timeout}, jobs, function(err){
-      if(resolved === false){ // new versions of redis will keep retrying in node v0.11x... 
+      if(resolved === false){ // new versions of redis will keep retrying in node v0.11x...
         should.exist(err);
         resolved = true;
         done();
@@ -166,7 +166,6 @@ describe('worker', function(){
         queue.enqueue(specHelper.queue, "quickDefine", []);
         worker.start();
       });
-
 
       it('will not work jobs that are not defined', function(done){
         var listener = worker.on('failure', function(q, job, failure){


### PR DESCRIPTION
This is useful if your job does not take any parameters. 
Before it used to work so that omitting arguments caused the arguments to be [undefined], which was a problem if your perform signature was "function(callback)". In that scenario callback was assigned undefined value when enqueuing with "enqueue('queue', 'job')"

Also fixed allDelayed to return empty hash if timestamps is empty