### PR TITLE
failed queue managment

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,41 @@ You can use the queue object to check on your wokrers:
 - **queue.allWorkingOn** = function(callback)`
   - returns a hash of the results of `queue.workingOn` with the worker names as keys.
 
+## Failed Job Managmet
+
+From time to time, your jobs/workers may fail.  Resque workers will move failed jobs to a specail `failed` queue which will store the original arguments of your job, the failing stack trace, and additional medatadata.
+
+![error example](LINKHERE)
+
+You can work with these failed jobs with the following methods:
+
+- **queue.failedCount** = function(callback)
+  - callback(error, failedCount)
+  - `failedCount` is the number of jobs in the failed queue
+
+- **queue.failed** = function(start, stop, callback)
+  - callback(error, failedJobs)
+  - `failedJobs` is an array listing the data of the failed jobs.  Each elemet looks like:
+
+```javascript
+{ worker: 'busted-worker-3',
+  queue: 'busted-queue',
+  payload: { class: 'busted_job', queue: 'busted-queue', args: [ 1, 2, 3 ] },
+  exception: 'ERROR_NAME',
+  error: 'I broke',
+  failed_at: 'Sun Apr 26 2015 14:00:44 GMT+0100 (BST)' }
+```
+
+- **queue.removeFailed** = function(failedJob, callback)
+  - callback(error)
+  - the input `failedJob` is an expanded node object representing the failed job, retrived via `queue.failed`
+
+- **queue.retryAndRemoveFailed** = function(failedJob, callback)
+  - callback(error)
+  - the input `failedJob` is an expanded node object representing the failed job, retrived via `queue.failed`
+  - this method will instantly re-enqueue a failed job back to its original queue, and delete the failed entry for that job
+
+
 ## Plugins
 
 Just like ruby's resque, you can write worker plugins.  They look look like this.  The 4 hooks you have are `before_enqueue`, `after_enqueue`, `before_perform`, and `after_perform`

--- a/README.md
+++ b/README.md
@@ -195,9 +195,9 @@ You can use the queue object to check on your wokrers:
 - **queue.allWorkingOn** = function(callback)`
   - returns a hash of the results of `queue.workingOn` with the worker names as keys.
 
-## Failed Job Managmet
+## Failed Job Managment
 
-From time to time, your jobs/workers may fail.  Resque workers will move failed jobs to a specail `failed` queue which will store the original arguments of your job, the failing stack trace, and additional medatadata.
+From time to time, your jobs/workers may fail.  Resque workers will move failed jobs to a special `failed` queue which will store the original arguments of your job, the failing stack trace, and additional medatadata.
 
 ![error example](LINKHERE)
 
@@ -209,7 +209,7 @@ You can work with these failed jobs with the following methods:
 
 - **queue.failed** = function(start, stop, callback)
   - callback(error, failedJobs)
-  - `failedJobs` is an array listing the data of the failed jobs.  Each elemet looks like:
+  - `failedJobs` is an array listing the data of the failed jobs.  Each element looks like:
 
 ```javascript
 { worker: 'busted-worker-3',
@@ -222,12 +222,14 @@ You can work with these failed jobs with the following methods:
 
 - **queue.removeFailed** = function(failedJob, callback)
   - callback(error)
-  - the input `failedJob` is an expanded node object representing the failed job, retrived via `queue.failed`
+  - the input `failedJob` is an expanded node object representing the failed job, retrieved via `queue.failed`
 
 - **queue.retryAndRemoveFailed** = function(failedJob, callback)
   - callback(error)
-  - the input `failedJob` is an expanded node object representing the failed job, retrived via `queue.failed`
+  - the input `failedJob` is an expanded node object representing the failed job, retrieved via `queue.failed`
   - this method will instantly re-enqueue a failed job back to its original queue, and delete the failed entry for that job
+
+
 
 
 ## Plugins

--- a/README.md
+++ b/README.md
@@ -229,9 +229,6 @@ You can work with these failed jobs with the following methods:
   - the input `failedJob` is an expanded node object representing the failed job, retrieved via `queue.failed`
   - this method will instantly re-enqueue a failed job back to its original queue, and delete the failed entry for that job
 
-
-
-
 ## Plugins
 
 Just like ruby's resque, you can write worker plugins.  They look look like this.  The 4 hooks you have are `before_enqueue`, `after_enqueue`, `before_perform`, and `after_perform`

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -317,6 +317,36 @@ queue.prototype.allWorkingOn = function(callback){
   });
 };
 
+queue.prototype.failedCount = function(callback){
+  var self = this;
+  self.connection.redis.llen(self.connection.key('failed'), function(err, length){
+    callback(err, length);
+  });
+};
+
+queue.prototype.failed = function(start, stop, callback){
+  var self = this;
+  var results = [];
+  self.connection.redis.lrange(self.connection.key('failed'), start, stop, function(err, data){
+    data.forEach(function(d){ results.push( JSON.parse(d) ); });
+    callback(err, results);
+  });
+};
+
+queue.prototype.removeFailed = function(failedJob, callback){
+  var self = this;
+  self.connection.redis.lrem(self.connection.key('failed'), 1, JSON.stringify(failedJob), callback);
+};
+
+queue.prototype.retryAndRemoveFailed = function(failedJob, callback){
+  var self = this;
+  self.removeFailed(failedJob, function(err, countFailed){
+    if(err){return callback(err, failedJob); }
+    if(countFailed < 1 ){return callback(new Error('This job is not in failed queue'), failedJob); }
+    self.enqueue(failedJob.queue, failedJob.payload.class, failedJob.payload.args, callback);
+  });
+};
+
 /////////////
 // helpers //
 /////////////

--- a/resque-web/Gemfile.lock
+++ b/resque-web/Gemfile.lock
@@ -2,13 +2,13 @@ GEM
   remote: http://rubygems.org/
   specs:
     mono_logger (1.1.0)
-    multi_json (1.10.1)
+    multi_json (1.11.0)
     rack (1.6.0)
     rack-protection (1.5.3)
       rack
     rake (10.4.2)
-    redis (3.2.0)
-    redis-namespace (1.5.1)
+    redis (3.2.1)
+    redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
     resque (1.25.2)
       mono_logger (~> 1.0)
@@ -21,16 +21,12 @@ GEM
       redis (~> 3.0)
       resque (~> 1.25)
       rufus-scheduler (~> 3.0)
-    rufus-scheduler (3.0.9)
-      tzinfo
-    sinatra (1.4.5)
+    rufus-scheduler (3.1.1)
+    sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
-      tilt (~> 1.3, >= 1.3.4)
-    thread_safe (0.3.4)
-    tilt (1.4.1)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
+      tilt (>= 1.3, < 3)
+    tilt (2.0.1)
     vegas (0.1.11)
       rack (>= 1.0.0)
 

--- a/resque-web/config.ru
+++ b/resque-web/config.ru
@@ -11,9 +11,10 @@ Resque.redis = Redis.new
 # Or, with custom options
 # Resque.redis = Redis.new({
 #   :host => "127.0.0.1", 
-#   :port => 6390, 
-#   :db => 1
+#   :port => 6379, 
+#   :db => 1,
 # })
+# Resque.redis.namespace = 'resque_test'
 
 run Rack::URLMap.new \
   "/" => Resque::Server.new

--- a/test/core/queue.js
+++ b/test/core/queue.js
@@ -308,12 +308,9 @@ describe('queue', function(){
           queue.removeFailed(failedJobs[0], function(err, removedJobs){
             should.not.exist(err);
             removedJobs.should.equal(1);
-            queue.removeFailed(failedJobs[1], function(err, removedJobs){
-              removedJobs.should.equal(0);
-              queue.failedCount(function(err, failedCount){
-                failedCount.should.equal(2);
-                done();
-              });
+            queue.failedCount(function(err, failedCount){
+              failedCount.should.equal(2);
+              done();
             });
           });
         });


### PR DESCRIPTION
## Failed Job Managment

From time to time, your jobs/workers may fail.  Resque workers will move failed jobs to a special `failed` queue which will store the original arguments of your job, the failing stack trace, and additional medatadata.

You can work with these failed jobs with the following methods:

- **queue.failedCount** = function(callback)
  - callback(error, failedCount)
  - `failedCount` is the number of jobs in the failed queue

- **queue.failed** = function(start, stop, callback)
  - callback(error, failedJobs)
  - `failedJobs` is an array listing the data of the failed jobs.  Each element looks like:

```javascript
{ worker: 'busted-worker-3',
  queue: 'busted-queue',
  payload: { class: 'busted_job', queue: 'busted-queue', args: [ 1, 2, 3 ] },
  exception: 'ERROR_NAME',
  error: 'I broke',
  failed_at: 'Sun Apr 26 2015 14:00:44 GMT+0100 (BST)' }
```

- **queue.removeFailed** = function(failedJob, callback)
  - callback(error)
  - the input `failedJob` is an expanded node object representing the failed job, retrieved via `queue.failed`

- **queue.retryAndRemoveFailed** = function(failedJob, callback)
  - callback(error)
  - the input `failedJob` is an expanded node object representing the failed job, retrieved via `queue.failed`
  - this method will instantly re-enqueue a failed job back to its original queue, and delete the failed entry for that job
