### PR TITLE
Problem deleting queue.  Queue isn't removed from list of queues.

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -117,7 +117,10 @@ queue.prototype.queues = function(callback){
 queue.prototype.delQueue = function(q, callback){
   var self = this;
   self.connection.redis.del(self.connection.key('queue', q), function(err){
-    callback(err);
+    if(err) return callback(err)
+    self.connection.redis.srem(self.connection.key('queues'), q, function(err){
+      callback(err);
+    })
   });
 };
 


### PR DESCRIPTION
Hi there,

Loving node-resque.  While doing some testing with our code I realized that the queues collection wasn't being properly cleaned up when I was calling delQueue.  This code might not totally match your style, but at least shows you the srem command to remove it from the queues collection. I figure a pull request is friendlier than an issue complaining about a bug :).  Thanks for the awesome work!