### PR TITLE
Ensure redis connections get released

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -98,7 +98,10 @@ connection.prototype.connect = function(callback){
 
 connection.prototype.disconnect = function(){
   var self = this;
-  return self.redis.quit();
+  // Only disconnect if we established the redis connection on our own.
+  if (!self.options.redis) {
+    return self.redis.quit();
+  }
 }
 
 connection.prototype.key = function(){

--- a/lib/multiWorker.js
+++ b/lib/multiWorker.js
@@ -170,7 +170,7 @@ multiWorker.prototype.cleanupWorker = function(worker){
   });
 
   if(self.options.toDisconnectProcessors === true){
-    worker.connection.redis.quit();
+    worker.connection.disconnect();
   }
 };
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -23,7 +23,7 @@ var queue = function(options, jobs, callback){
 
 queue.prototype.end = function(callback){
   var self = this;
-  self.connection.redis.quit();
+  self.connection.disconnect();
   process.nextTick(function(){
     if(typeof callback === 'function'){ callback(); }
   });

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -53,9 +53,12 @@ scheduler.prototype.end = function(callback) {
   self.running = false;
   if(self.processing === false){
     clearTimeout(self.timer);
-    self.emit('end');
-    process.nextTick(function(){
-      if(typeof callback === 'function'){ callback(); }
+    self.queue.end(function() {
+      self.emit('end');
+      self.connection.disconnect();
+      process.nextTick(function(){
+        if(typeof callback === 'function'){ callback(); }
+      });
     });
   }else if(self.processing === true){
     setTimeout(function(){

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -67,8 +67,10 @@ worker.prototype.end = function(callback) {
     }, self.options.timeout);
   }else{
     self.untrack(self.name, self.stringQueues(), function(){
-      self.emit('end');
-      if(typeof callback === 'function'){ callback(); }
+      self.queueObject.end(function() {
+        self.emit('end');
+        if(typeof callback === 'function'){ callback(); }
+      });
     });
   }
 };


### PR DESCRIPTION
Without this change, calling `.end` on a scheduler does not close the schedulers connection to redis and does not actually stop the worker instance inside the scheduler (which is holding another redis connection itself).