### PR TITLE
Fix: enquening new job when previosu one was locked

### DIFF
--- a/lib/plugins/queueLock.js
+++ b/lib/plugins/queueLock.js
@@ -32,8 +32,7 @@ queueLock.prototype.before_enqueue = function(callback){
         }else{
           self.worker.connection.redis.set(key, timeout, function(err){
             self.worker.connection.redis.get(key, function(err, redisTimeout){
-              redisTimeout = parseInt(redisTimeout);
-              callback(null, now > redisTimeout);              
+              callback(err, !err);
             });
           });
         }

--- a/lib/plugins/queueLock.js
+++ b/lib/plugins/queueLock.js
@@ -31,9 +31,7 @@ queueLock.prototype.before_enqueue = function(callback){
           callback(null, false);
         }else{
           self.worker.connection.redis.set(key, timeout, function(err){
-            self.worker.connection.redis.get(key, function(err, redisTimeout){
-              callback(err, !err);
-            });
+            callback(err, !err);
           });
         }
       });


### PR DESCRIPTION
after setting new key lock timeout in queueLock its pointless to check if `now` is greater than timeout beacuse it will never be, so callback will always return false as second argument and then job will not be pushed to queue which in my opinion is a bug especially that before_enqueue event is called only once after start