### PR TITLE
Handle slow redis connection establishment

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -132,6 +132,11 @@ scheduler.prototype.pollAgainLater = function(){
 
 scheduler.prototype.tryForMaster = function(callback) {
   var self = this;
+  
+  if(!self.connection || !self.connection.redis) {
+    return callback();
+  }
+
   var masterKey = self.connection.key('resque_scheduler_master_lock');
   self.connection.redis.setnx(masterKey, self.options.name, function(error, locked){
     if(error){ return callback(error); }


### PR DESCRIPTION
If the redis connection take a long time to establish during startup, then it's possible that `scheduler. tryForMaster` will crash with a NPE on this line:

```
   var masterKey = self.connection.key('resque_scheduler_master_lock');
```

This PR adds a check to ensure that the connection has been established before proceeding with `tryForMaster`.

We discovered this problem during a restart that happened during a Redis failover. During the failover period, the process was continually crashing and restarting due to this problem. 

