### PR TITLE
'package' wrapped so IDEs don't go on keyword red alert

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -47,9 +47,9 @@ connection.prototype.connect = function(callback){
 
   }else{
 
-    if(self.options.package && !self.options.pkg) {
+    if(self.options['package'] && !self.options.pkg) {
       self.emit('Depreciation warning: You need to use \'pkg\' instead of \'package\'! Please update your configuration.');
-      self.options.pkg = self.options.package;
+      self.options.pkg = self.options['package'];
     }
     var pkg = require(self.options.pkg);
     self.redis = pkg.createClient(self.options.port, self.options.host, self.options.options);


### PR DESCRIPTION
Just changed it to string hash access.

Good that there's a deprecation warning now.