### PR TITLE
Fix delayed job removal

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -163,14 +163,18 @@ queue.prototype.delDelayed = function(q, func, args, callback){
       var timestamps = [];
       members.forEach(function(key){
         started++;
-        self.connection.redis.lrem(key, 0, search, function(){
-          self.connection.redis.srem(self.connection.key("timestamps:" + search), key, function(){
-            timestamps.push(key.split(":")[key.split(":").length - 1]);
-            started--;
-            if(started === 0){
-              if(typeof callback === 'function'){ callback(err, timestamps); }
-            }
-          });
+        self.connection.redis.lrem(self.connection.key(key), 0, search, function(err, count){
+          if(count > 0) {
+            self.connection.redis.srem(self.connection.key("timestamps:" + search), key, function(){
+              timestamps.push(key.split(":")[key.split(":").length - 1]);
+              started--;
+              if(started === 0){
+                if(typeof callback === 'function'){ callback(err, timestamps); }
+              }
+            });
+          } else {
+            if(typeof callback === 'function'){ callback(err, []); }
+          }
         });
       });
     }

--- a/test/core/queue.js
+++ b/test/core/queue.js
@@ -172,7 +172,7 @@ describe('queue', function(){
       });
     });
 
-    it('can delete a delayed job and delayed queue should be empty', function(done){
+    it('can delete a delayed job, and delayed queue should be empty', function(done){
       queue.enqueueAt(10000, specHelper.queue, 'someJob', [1,2,3], function(){
         queue.delDelayed(specHelper.queue, 'someJob', [1,2,3], function(err, timestamps){
           queue.allDelayed(function(err, hash){

--- a/test/core/queue.js
+++ b/test/core/queue.js
@@ -172,6 +172,19 @@ describe('queue', function(){
       });
     });
 
+    it('can delete a delayed job and delayed queue should be empty', function(done){
+      queue.enqueueAt(10000, specHelper.queue, 'someJob', [1,2,3], function(){
+        queue.delDelayed(specHelper.queue, 'someJob', [1,2,3], function(err, timestamps){
+          queue.allDelayed(function(err, hash){
+            hash.should.be.empty();
+            timestamps.length.should.equal(1);
+            timestamps[0].should.equal('10');
+            done();
+          });
+        });
+      });
+    });
+
     it('can handle single arguments without explicit array', function(done){
       queue.enqueue(specHelper.queue, 'someJob', 1, function(){
         specHelper.popFromQueue(function(err, obj){
@@ -247,11 +260,12 @@ describe('queue', function(){
         queue.enqueueAt(12000, specHelper.queue, 'noParams', function(){
           queue.allDelayed(function(err, hash){
             Object.keys(hash).length.should.equal(2);
-            queue.delDelayed(specHelper.queue, 'noParams');
             queue.delDelayed(specHelper.queue, 'noParams', function(){
-              queue.allDelayed(function(err, hash){
-                hash.should.be.empty;
-                done();
+              queue.delDelayed(specHelper.queue, 'noParams', function(){
+                queue.allDelayed(function(err, hash){
+                  hash.should.be.empty;
+                  done();
+                });
               });
             });
           });


### PR DESCRIPTION
* Prepend queue namespace to delayed job key found in timestamps before attempting to remove from delayed queue list, and added check that the removal was successful.
* Created new test, and fixed another which was returning done() multiple times because of the changes to delDelayed.