### PR TITLE
Dockerize resque-web

### DIFF
--- a/resque-web/Dockerfile
+++ b/resque-web/Dockerfile
@@ -11,4 +11,6 @@ RUN bundle install
 
 COPY . /usr/src/app
 
+EXPOSE 9292
+
 CMD ["/bin/sh", "-c", "bundle exec rackup --host=0.0.0.0"]

--- a/resque-web/Dockerfile
+++ b/resque-web/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2-alpine
+MAINTAINER 	Corbin Uselton <corbinu@decimal.io>
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY Gemfile /usr/src/app/
+COPY Gemfile.lock /usr/src/app/
+
+RUN bundle install
+
+COPY . /usr/src/app
+
+CMD ["/bin/sh", "-c", "bundle exec rackup --host=0.0.0.0"]

--- a/resque-web/config.ru
+++ b/resque-web/config.ru
@@ -8,15 +8,37 @@ require 'resque-retry'
 require 'resque-retry/server'
 require 'yaml'
 
-Resque.redis = Redis.new
+redis_host = ENV['REDIS_HOST']
+redis_port = ENV['REDIS_PORT']
+redis_db = ENV['REDIS_DB']
+redis_namespace = ENV['REDIS_NAMESPACE']
+AUTH_USERNAME = ENV['AUTH_USERNAME']
+AUTH_PASSWORD = ENV['AUTH_PASSWORD']
 
-# Or, with custom options
-# Resque.redis = Redis.new({
-#   :host => "127.0.0.1",
-#   :port => 6379,
-#   :db => 1,
-# })
-# Resque.redis.namespace = 'resque_test'
+redis_host ||= "redis"
+redis_port ||=  6379
+redis_db ||=  1
+
+Resque.redis = Redis.new({
+  :host => redis_host,
+  :port => redis_port,
+  :db => redis_db,
+})
+
+connecting = "Connecting to redis db #{redis_db} on #{redis_host}:#{redis_port}"
+
+if (defined?(redis_namespace))
+  connecting << " with namespace #{redis_namespace}"
+  Resque.redis.namespace = redis_namespace
+end
+
+if AUTH_PASSWORD
+  Resque::Server.use Rack::Auth::Basic do |username, password|
+    username == AUTH_USERNAME && password == AUTH_PASSWORD
+  end
+end
+
+puts connecting
 
 run Rack::URLMap.new \
   "/" => Resque::Server.new

--- a/resque-web/docker-compose.yml
+++ b/resque-web/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '2'
+
+services:
+  web:
+    image: corbinu/node-resque-web
+    ports:
+      - "9292:9292"
+    depends_on:
+      - redis
+    env_file:
+      - env
+
+  redis:
+    image: redis:3-alpine
+    ports:
+      - "6379:6379"
+    env_file:
+      - env
+    depends_on:
+      - redisdata
+    volumes_from:
+      - redisdata
+
+  redisdata:
+    image: tianon/true
+    volumes:
+      - /data

--- a/resque-web/env
+++ b/resque-web/env
@@ -1,0 +1,3 @@
+AUTH_USERNAME=admin
+AUTH_PASSWORD=password
+REDIS_NAMESPACE=node-resque

--- a/resque-web/readme.md
+++ b/resque-web/readme.md
@@ -31,3 +31,68 @@ gem install bundler
 bundle install
 bundle exec rackup
 ```
+
+## Docker
+
+# Docker image for Resque Web
+
+## How to use
+
+### Use as standalone container
+
+You can use `docker run` to run this image directly.
+
+```bash
+docker run -p 9292:9292 -e REDIS_HOST=10.0.0.10 corbinu/resque-web
+```
+
+### Use Docker Compose
+
+[Docker Compose](https://docs.docker.com/compose/) is the recommended way to run this image with Redis database.
+
+A sample `docker-compose.yml` can be found in this repo.
+
+```yaml
+version: '2'
+
+services:
+  web:
+    image: corbinu/node-resque-web
+    ports:
+      - "9292:9292"
+    depends_on:
+      - db
+    env_file:
+      - env
+
+  db:
+    image: redis:3-alpine
+    ports:
+      - "6379:6379"
+    env_file:
+      - env
+    depends_on:
+      - dbdata
+    volumes_from:
+      - dbdata
+
+  dbdata:
+    image: tianon/true
+    volumes:
+      - /data
+```
+
+Then use `docker-compose up -d` to start Resque Web server.
+
+Configurations:
+
+Environment variable      | Description | Default value (used by Docker Compose - `env` file)
+--------------------      | ----------- | ---------------------------
+REDIS_HOST                | Redis host  | redis
+REDIS_PORT                | Redis port |  6379
+REDIS_DB                  | Redis DB | 1
+REDIS_NAMESPACE           | Redis namespace | none
+AUTH_USERNAME             | Username for basic auth | none
+AUTH_PASSWORD             | Password for basic auth | none
+
+If Docker Compose is used, you can just modify `env` file in the same directory of `docker-compose.yml` file to update those environment variables.


### PR DESCRIPTION
For my own use I dockerized the resque web app. 

If your interested in pulling it in simply update the readme and docker-compose to point at your own image. Otherwise we will simply maintain mine.

Let me know if you want any changes.