### PR TITLE
Check if setInterval().unref() exists before call

### DIFF
--- a/lib/eventLoopDelay.js
+++ b/lib/eventLoopDelay.js
@@ -3,7 +3,7 @@
 module.exports = function(limit, interval, fn){
   var start = process.hrtime();
 
-  setInterval(function(){
+  var timeout = setInterval(function(){
     var delta = process.hrtime(start);
     var nanosec = delta[0] * 1e9 + delta[1];
     var ms = nanosec / 1e6;
@@ -14,5 +14,9 @@ module.exports = function(limit, interval, fn){
       fn(false, Math.round(n));
     }
     start = process.hrtime();
-  }, interval).unref();
+  }, interval);
+  
+  if (timeout.unref) {
+    timeout.unref();
+  }
 };


### PR DESCRIPTION
Test if unref() exists before calling it.  This allows node-resque to work in a browser context (such as an electron render process).