### PR TITLE
Fix hang when `worker.looping=false` (#161)

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -108,12 +108,8 @@ worker.prototype.poll = function(nQueue, callback){
       self.connection.redis.lpop(self.connection.key('queue', self.queue), function(error, resp){
         if(!error && resp){
           var currentJob = JSON.parse(resp.toString());
-          if(self.options.looping){
-            self.result = null;
-            self.perform(currentJob);
-          }else{
-            if(typeof callback === 'function'){ callback(currentJob); }
-          }
+          self.result = null;
+          self.perform(currentJob);
         }else{
           if(error){
             self.emit('error', self.queue, null, error);


### PR DESCRIPTION
`worker.perform()` needs to be run regardless of `self.looping` value.

`worker.peform()` also has a check for `self.looping` and will determine if `self.pause()` is called.

With `self.looping=false` the worker will stop after the first message and will not check the queue again until `worker.poll()` is run.