### PR TITLE
remove domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,12 @@ You can work with these failed jobs with the following methods:
   - callback(error, failedJobs)
   - `failedJobs` is an array listing the data of the failed jobs.  Each element looks like:
 
+### Failing a Job
+
+It is *very* important that your jobs handle uncaughtRejections and other errors of this type properly.  As of `node-resque` version 4, we no longer use `domains` to catch what would otherwise be crash-inducing errors in your jobs.  This means that a job which causes your application to crash WILL BE LOST FOREVER.  Please use `catch()` on your promises, handle all of your callbacks, and otherwise write robust node.js applications.
+
+If you choose to use `domains`, `process.onExit`, or any other method of "catching" a process crash, you can still move the job `node-resque` was working on to the redis error queue with `worker.fail(error, callback)`.  
+
 ```javascript
 { worker: 'busted-worker-3',
   queue: 'busted-queue',

--- a/examples/errorExample.js
+++ b/examples/errorExample.js
@@ -33,9 +33,15 @@ var jobs = {
       jobsToComplete--;
       shutdown();
 
-      MISSING_VAR + THING;
+      // A ReferenceError like this would cause the application to crash
+      // and your job would be lost.
+      // If you have an unsafe job like this, consider domains maybe?
+      //MISSING_VAR + THING;
 
-      callback(null);
+      // however jobs which return an error callback properly will be
+      // logged in redis accordingly
+      var error = new Error('broken message from job');
+      callback(error);
     },
   },
 };
@@ -71,7 +77,7 @@ worker.on('pause',           function(){ console.log('worker paused'); });
 
 var queue = new NR.queue({connection: connectionDetails}, jobs);
 queue.connect(function(){
-  queue.enqueue('default', 'brokenJob', {a: 1, b: 2});
+  queue.enqueue('default', 'brokenJob', [1, 2]);
   jobsToComplete = 1;
 });
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -2,7 +2,6 @@ var os = require('os');
 var util = require('util');
 var async = require('async');
 var exec = require('child_process').exec;
-var domain = require('domain');
 var EventEmitter = require('events').EventEmitter;
 var connection   = require(__dirname + '/connection.js').connection;
 var queue        = require(__dirname + '/queue.js').queue;
@@ -142,93 +141,71 @@ worker.prototype.perform = function(job, callback){
   var self = this;
   var returnCounter = 0; // a state counter to prevent multiple returns from poor jobs or plugins
   var callbackError = new Error('refusing to continue with job, multiple callbacks detected');
-  var d = domain.create();
   self.job = job;
-  d.on('error', function(err){
-    self.error = err;
+  self.error = null;
+  if(!self.jobs[job['class']]){
+    self.error = new Error('No job defined for class "' + job['class'] + '"');
+    self.completeJob(true, callback);
+  }else{
+    var cb = self.jobs[job['class']].perform;
+    self.emit('job', self.queue, job);
 
-    // if we catch a failure from within the job, we need run the after_perform plugin methods
-    if(returnCounter === 1){
-      pluginRunner.runPlugins(self, 'after_perform', job['class'], self.queue, self.jobs[job['class']], job.args, function(e, toRun){
-        if(self.error === undefined && e){ self.error = e; }
+    if(cb){
+      pluginRunner.runPlugins(self, 'before_perform', job['class'], self.queue, self.jobs[job['class']], job.args, function(err, toRun){
         returnCounter++;
-        if(returnCounter !== 2){
+        if(returnCounter !== 1){
           self.emit('failure', self.queue, job, callbackError);
+        }else if(toRun === false){
+          self.completeJob(false, callback);
         }else{
-          self.completeJob(true, callback);
+          self.error = err;
+          self.workingOn(job);
+          var args;
+          if(job.args === undefined || (job.args instanceof Array) === true){
+            args = job.args;
+          }else{
+            args = [job.args];
+          }
+
+          var combinedInputs = [].slice.call(args).concat([function(err, result){
+            returnCounter++;
+            if(returnCounter !== 2){
+              self.emit('failure', self.queue, job, callbackError);
+            }else{
+              self.error = err;
+              self.result = result;
+              pluginRunner.runPlugins(self, 'after_perform', job['class'], self.queue, self.jobs[job['class']], job.args, function(e, toRun){
+                if(self.error === undefined && e){ self.error = e; }
+                returnCounter++;
+                if(returnCounter !== 3){
+                  self.emit('failure', self.queue, job, callbackError);
+                }else{
+                  self.completeJob(true, callback);
+                }
+              });
+            }
+          }]);
+
+          // When returning the payload back to redis (on error), it is important that the orignal payload is preserved
+          // To help with this, we can stry to make the inputs to the job immutible
+          // https://github.com/taskrabbit/node-resque/issues/99
+          // Note: if an input is a string or a number, you CANNOT freeze it saddly.
+          for(var i in combinedInputs){
+            if((typeof combinedInputs[i] === 'object') && (combinedInputs[i] !== null)){
+              Object.freeze(combinedInputs[i]);
+            }
+          }
+
+          cb.apply(self, combinedInputs);
         }
       });
+
     }else{
+
+      self.error = new Error('Missing Job: ' + job['class']);
       self.completeJob(true, callback);
     }
-  });
-
-  d.run(function(){
-    self.error = null;
-    if(!self.jobs[job['class']]){
-      self.error = new Error('No job defined for class "' + job['class'] + '"');
-      self.completeJob(true, callback);
-    }else{
-      var cb = self.jobs[job['class']].perform;
-      self.emit('job', self.queue, job);
-
-      if(cb){
-        pluginRunner.runPlugins(self, 'before_perform', job['class'], self.queue, self.jobs[job['class']], job.args, function(err, toRun){
-          returnCounter++;
-          if(returnCounter !== 1){
-            self.emit('failure', self.queue, job, callbackError);
-          }else if(toRun === false){
-            self.completeJob(false, callback);
-          }else{
-            self.error = err;
-            self.workingOn(job);
-            var args;
-            if(job.args === undefined || (job.args instanceof Array) === true){
-              args = job.args;
-            }else{
-              args = [job.args];
-            }
-
-            var combinedInputs = [].slice.call(args).concat([function(err, result){
-              returnCounter++;
-              if(returnCounter !== 2){
-                self.emit('failure', self.queue, job, callbackError);
-              }else{
-                self.error = err;
-                self.result = result;
-                pluginRunner.runPlugins(self, 'after_perform', job['class'], self.queue, self.jobs[job['class']], job.args, function(e, toRun){
-                  if(self.error === undefined && e){ self.error = e; }
-                  returnCounter++;
-                  if(returnCounter !== 3){
-                    self.emit('failure', self.queue, job, callbackError);
-                  }else{
-                    self.completeJob(true, callback);
-                  }
-                });
-              }
-            }]);
-
-            // When returning the payload back to redis (on error), it is important that the orignal payload is preserved
-            // To help with this, we can stry to make the inputs to the job immutible
-            // https://github.com/taskrabbit/node-resque/issues/99
-            // Note: if an input is a string or a number, you CANNOT freeze it saddly.
-            for(var i in combinedInputs){
-              if((typeof combinedInputs[i] === 'object') && (combinedInputs[i] !== null)){
-                Object.freeze(combinedInputs[i]);
-              }
-            }
-
-            cb.apply(self, combinedInputs);
-          }
-        });
-
-      }else{
-
-        self.error = new Error('Missing Job: ' + job['class']);
-        self.completeJob(true, callback);
-      }
-    }
-  });
+  }
 };
 
 // #performInline is used to run a job payload directly.
@@ -277,7 +254,7 @@ worker.prototype.completeJob = function(toRespond, callback){
   var self = this;
   var job = self.job;
   if(self.error){
-    self.fail(self.error, job);
+    self.fail(self.error);
   }else if(toRespond){
     self.succeed(job);
   }
@@ -315,9 +292,10 @@ worker.prototype.succeed = function(job){
   });
 };
 
-worker.prototype.fail = function(err, job){
+worker.prototype.fail = function(err, callback){
   var self = this;
   var jobs = [];
+  var failingJob = self.job;
 
   jobs.push(function(done){
     self.connection.redis.incr(self.connection.key('stat', 'failed'), done);
@@ -328,13 +306,16 @@ worker.prototype.fail = function(err, job){
   });
 
   jobs.push(function(done){
-    self.connection.redis.rpush(self.connection.key('failed'), JSON.stringify(self.failurePayload(err, job)), done);
+    self.connection.redis.rpush(self.connection.key('failed'), JSON.stringify(self.failurePayload(err, failingJob)), done);
   });
 
   async.series(jobs, function(error){
-    if(error){ self.emit('error', null, null, error); }
-    else{
-      self.emit('failure', self.queue, job, err);
+    if(error){
+      self.emit('error', null, null, error);
+      if(typeof callback === 'function'){ return callback(error); }
+    }else{
+      self.emit('failure', self.queue, failingJob, err);
+      if(typeof callback === 'function'){ return callback(); }
     }
   });
 };


### PR DESCRIPTION
From the new README:

> It is *very* important that your jobs handle uncaughtRejections and other errors of this type properly.  As of `node-resque` version 4, we no longer use `domains` to catch what would otherwise be crash-inducing errors in your jobs.  This means that a job which causes your application to crash WILL BE LOST FOREVER.  Please use `catch()` on your promises, handle all of your callbacks, and otherwise write robust node.js applications.

> If you choose to use `domains`, `process.onExit`, or any other method of "catching" a process crash, you can still move the job `node-resque` was working on to the redis error queue with `worker.fail(error, callback)`.  

---
This is a breaking change which will trigger the v4 release
---

Solves https://github.com/taskrabbit/node-resque/issues/166.  Visit this issue for a discussion of the possible alternative solutions