### PR TITLE
Require all worker end methods (succeed and fail) to wait for the callback

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -253,26 +253,35 @@ worker.prototype.performInline = function(func, args, callback){
 worker.prototype.completeJob = function(toRespond, callback){
   var self = this;
   var job = self.job;
+  var jobs = [];
+
   if(self.error){
-    self.fail(self.error);
+    jobs.push(function(done){
+      self.fail(self.error, done);
+    });
   }else if(toRespond){
-    self.succeed(job);
+    jobs.push(function(done){
+      self.succeed(job, done);
+    });
   }
 
-  self.doneWorking(function(error){
+  jobs.push(function(done){
+    self.doneWorking(done);
+  });
+
+  async.series(jobs, function(error){
     if(error){ self.emit('error', null, null, error); }
     self.job = null;
-    process.nextTick((function(){
-      if(self.options.looping){
-        return self.poll();
-      }else if(typeof callback === 'function'){
-        callback(error);
-      }
-    }));
+
+    if(self.options.looping){
+      return self.poll();
+    }else if(typeof callback === 'function'){
+      return callback(error);
+    }
   });
 };
 
-worker.prototype.succeed = function(job){
+worker.prototype.succeed = function(job, callback){
   var self = this;
   var jobs = [];
 
@@ -286,9 +295,9 @@ worker.prototype.succeed = function(job){
 
   async.series(jobs, function(error){
     if(error){ self.emit('error', null, null, error); }
-    else{
-      self.emit('success', self.queue, job, self.result);
-    }
+    else{ self.emit('success', self.queue, job, self.result); }
+
+    if(typeof callback === 'function'){ return callback(); }
   });
 };
 

--- a/test/core/multiWorker.js
+++ b/test/core/multiWorker.js
@@ -89,7 +89,7 @@ if(specHelper.pkg === 'fakeredis'){
         setTimeout(function(){
           multiWorker.workers.length.should.equal(1);
           multiWorker.end(done);
-        }, checkTimeout + 1);
+        }, (checkTimeout * 2) + 500);
       });
     });
 


### PR DESCRIPTION
This PR change the internal worker methods of `worker.fail` and `worker.succeed` to use (and wait for) a callback internally.  This prevents the followup methods, specifically `worker.poll` to fire  before they complete.  

This was causing a problem where `worker.poll` could potentially change the value `worker.queue` *before* the success (or failure) event fires, which reads from `worker.queue`