### PR TITLE
offload pid parsing to OS to reduce returned buffer size

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -456,7 +456,6 @@ worker.prototype.getPids = function(callback){
   if(process.platform === 'win32'){
     cmd = 'for /f "usebackq tokens=2 skip=2" %i in (`tasklist /nh`) do @echo %i';
   }else{
-    // cmd = 'ps awx | grep -v grep';
     cmd = 'ps -ef | awk \'{print $2}\'';
   }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -456,7 +456,8 @@ worker.prototype.getPids = function(callback){
   if(process.platform === 'win32'){
     cmd = 'for /f "usebackq tokens=2 skip=2" %i in (`tasklist /nh`) do @echo %i';
   }else{
-    cmd = 'ps awx | grep -v grep';
+    // cmd = 'ps awx | grep -v grep';
+    cmd = 'ps -ef | awk \'{print $2}\'';
   }
 
   var child = exec(cmd, function(error, stdout, stderr){
@@ -465,7 +466,7 @@ worker.prototype.getPids = function(callback){
       line = line.trim();
       if(line.length > 0){
         var pid = parseInt(line.split(' ')[0]);
-        pids.push(pid);
+        if(!isNaN(pid)){ pids.push(pid); }
       }
     });
 

--- a/test/core/multiWorker.js
+++ b/test/core/multiWorker.js
@@ -89,7 +89,7 @@ if(specHelper.pkg === 'fakeredis'){
         setTimeout(function(){
           multiWorker.workers.length.should.equal(1);
           multiWorker.end(done);
-        }, (checkTimeout * 2) + 500);
+        }, (checkTimeout * 3) + 500);
       });
     });
 


### PR DESCRIPTION
When getting a list of all runing PIDs on *this* host (so we can cleanup any previously crashed workers), we had previously taken in the whole PS string and parsed it in Node.  If your OS is busy, this list can be quite large and crash your application.  Now, we'll offload some of the parsing of this list to AWK (another process) and only get back a list of PIDs to parse.

This shouldn't harm compatibility, as AWK is ubiquitous as GREP.