### PR TITLE
Ensure enquerueIn time is an integer.

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -130,7 +130,7 @@ queue.prototype.enqueueIn = function(time, q, func, args, callback){
   }
 
   args = arrayify(args);
-  var timestamp = (new Date().getTime()) + time;
+  var timestamp = (new Date().getTime()) + parseInt(time, 10);
   self.enqueueAt(timestamp, q, func, args, callback);
 };
 


### PR DESCRIPTION
I had a bug where due to type conversion, time was passed as a string, and the resulting timestap was not correct. This should keep others from falling in that trap, and I think is a good idea.