### PR TITLE
Adding noop plugin to ignore failed jobs.

### DIFF
--- a/lib/plugins/noop.js
+++ b/lib/plugins/noop.js
@@ -1,0 +1,27 @@
+var noop = function(worker, func, queue, job, args, options){
+  var self = this;
+  self.name = 'noop';
+  self.worker = worker;
+  self.queue = queue;
+  self.func = func;
+  self.job = job;
+  self.args = args;
+  self.options = options;
+
+  if(self.worker.queueObject){
+    self.queueObject = self.worker.queueObject;
+  }else{
+    self.queueObject = self.worker;
+  }
+};
+
+noop.prototype.after_perform = function(callback){
+  var self = this;
+  if(self.worker.error){
+    delete self.worker.error;
+  }
+
+  callback(null, true);
+};
+
+exports.noop = noop;

--- a/lib/plugins/noop.js
+++ b/lib/plugins/noop.js
@@ -18,6 +18,11 @@ var noop = function(worker, func, queue, job, args, options){
 noop.prototype.after_perform = function(callback){
   var self = this;
   if(self.worker.error){
+    if(typeof self.options.logger === 'function'){
+      self.options.logger(self.worker.error);
+    } else{
+      console.log(self.worker.error);
+    }
     delete self.worker.error;
   }
 

--- a/test/plugins/noop.js
+++ b/test/plugins/noop.js
@@ -1,0 +1,119 @@
+var specHelper = require(__dirname + '/../_specHelper.js').specHelper;
+var should = require('should');
+
+describe('plugins', function(){
+  describe('noop', function(){
+    var queue;
+    var scheduler;
+
+    var jobs = {
+      'brokenJob': {
+        plugins: ['noop'],
+        pluginOptions: {'noop': {}},
+        perform: function(a, b, callback){
+          callback(new Error('BUSTED'), null);
+        }
+      },
+      'happyJob': {
+        plugins: ['noop'],
+        pluginOptions: {'noop': {}},
+        perform: function(a, b, callback){
+          callback(null, null);
+        }
+      }
+    };
+
+    before(function(done){
+      specHelper.connect(function(){
+        specHelper.cleanup(function(){
+          queue = new specHelper.NR.queue({connection:
+                    specHelper.cleanConnectionDetails(), queue: specHelper.queue}, jobs);
+          scheduler = new specHelper.NR.scheduler({connection:
+                    specHelper.cleanConnectionDetails(), timeout: specHelper.timeout});
+          scheduler.connect(function(){
+            scheduler.start();
+            queue.connect(done);
+          });
+        });
+      });
+    });
+
+    after(function(done){
+      scheduler.end(done);
+    });
+
+    afterEach(function(done){
+      specHelper.cleanup(done);
+    });
+
+    it('will work fine with non-crashing jobs', function(done){
+      queue.enqueue(specHelper.queue, 'happyJob', [1, 2], function(){
+        queue.length(specHelper.queue, function(err, length){
+          length.should.equal(1);
+
+          var worker = new specHelper.NR.worker({
+            connection: specHelper.cleanConnectionDetails(),
+            timeout:    specHelper.timeout,
+            queues:     specHelper.queue
+          }, jobs);
+
+          var complete = function(){
+            specHelper.redis.llen('resque_test:failed', function(error, length){
+              length.should.equal(0);
+              worker.end(done);
+            });
+          };
+
+          worker.connect(function(){
+
+            worker.on('success', function(){
+              complete();
+            });
+
+            worker.on('failure', function(){
+              throw new Error('should never get here');
+            });
+
+            worker.start();
+          });
+        });
+      });
+    });
+
+    it('will prevent any failed jobs from ending in the failed queue', function(done){
+      queue.enqueue(specHelper.queue, 'brokenJob', [1, 2], function(){
+        queue.length(specHelper.queue, function(err, length){
+          length.should.equal(1);
+
+          var worker = new specHelper.NR.worker({
+            connection: specHelper.cleanConnectionDetails(),
+            timeout:    specHelper.timeout,
+            queues:     specHelper.queue
+          }, jobs);
+
+          var complete = function(){
+
+            specHelper.redis.llen('resque_test:failed', function(error, length){
+              length.should.equal(0);
+              worker.end(done);
+            });
+          };
+
+          worker.connect(function(){
+
+            worker.on('success', function(){
+              complete();
+            });
+
+            worker.on('failure', function(){
+              throw new Error('should never get here');
+            });
+
+            worker.start();
+          });
+        });
+      });
+    });
+
+  });
+});

--- a/test/plugins/noop.js
+++ b/test/plugins/noop.js
@@ -5,18 +5,27 @@ describe('plugins', function(){
   describe('noop', function(){
     var queue;
     var scheduler;
+    var loggedErrors = [];
 
     var jobs = {
       'brokenJob': {
         plugins: ['noop'],
-        pluginOptions: {'noop': {}},
+        pluginOptions: {'noop': {
+          logger: function(error){
+            loggedErrors.push(error);
+          }
+        }},
         perform: function(a, b, callback){
           callback(new Error('BUSTED'), null);
         }
       },
       'happyJob': {
         plugins: ['noop'],
-        pluginOptions: {'noop': {}},
+        pluginOptions: {'noop': {
+          logger: function(error){
+            loggedErrors.push(error);
+          }
+        }},
         perform: function(a, b, callback){
           callback(null, null);
         }
@@ -36,6 +45,11 @@ describe('plugins', function(){
           });
         });
       });
+    });
+
+    beforeEach(function(done){
+      loggedErrors = [];
+      done();
     });
 
     after(function(done){
@@ -67,6 +81,7 @@ describe('plugins', function(){
           worker.connect(function(){
 
             worker.on('success', function(){
+              loggedErrors.length.should.equal(0);
               complete();
             });
 
@@ -102,6 +117,7 @@ describe('plugins', function(){
           worker.connect(function(){
 
             worker.on('success', function(){
+              loggedErrors.length.should.equal(1);
               complete();
             });
 


### PR DESCRIPTION
Attempt at Noop Fail Handler [https://github.com/taskrabbit/node-resque/issues/170]
My thought behind this is: What if you don't care about failures and you never go back and process them? They'll just fill up your Redis deployment over time. Ideally, I'd like to log the error out but there is no universal way that resque users log so my approach is just to throw the error away. 

Thoughts?