### PR TITLE
Stringify elements of args array that are of object type

### DIFF
--- a/lib/plugins/retry.js
+++ b/lib/plugins/retry.js
@@ -34,7 +34,9 @@ retry.prototype.argsKey = function(){
   var self = this;
   // return crypto.createHash('sha1').update(self.args.join('-')).digest('hex');
   if(!self.args || self.args.length === 0){ return ''; }
-  return self.args.join('-');
+  return self.args.map(function(elem){
+    return typeof(elem) === "object" ? JSON.stringify(elem) : elem;
+  }).join("-");
 };
 
 retry.prototype.retryKey = function(){


### PR DESCRIPTION
Stringify elements of args array that are of object type to avoid creating an [object object] key in redis