### PR TITLE
Support string error

### DIFF
--- a/lib/plugins/retry.js
+++ b/lib/plugins/retry.js
@@ -91,13 +91,15 @@ retry.prototype.saveLastError = function (callback) {
     (('0' + now.getHours()).slice(-2)) + ':' +
     (('0' + now.getMinutes()).slice(-2)) + ':' +
     (('0' + now.getSeconds()).slice(-2))
+  var backtrace = self.worker.error.stack ?
+    self.worker.error.stack.split(os.EOL) || [] : []
 
   var data = {
     failed_at: failedAt,
     payload: self.args,
     exception: String(self.worker.error),
     error: String(self.worker.error),
-    backtrace: self.worker.error.stack.split(os.EOL) || [],
+    backtrace: backtrace,
     worker: self.func,
     queue: self.queue
   }

--- a/lib/plugins/retry.js
+++ b/lib/plugins/retry.js
@@ -91,8 +91,8 @@ retry.prototype.saveLastError = function (callback) {
     (('0' + now.getHours()).slice(-2)) + ':' +
     (('0' + now.getMinutes()).slice(-2)) + ':' +
     (('0' + now.getSeconds()).slice(-2))
-  var backtrace = self.worker.error.stack ?
-    self.worker.error.stack.split(os.EOL) || [] : []
+  var backtrace = self.worker.error.stack
+    ? self.worker.error.stack.split(os.EOL) || [] : []
 
   var data = {
     failed_at: failedAt,


### PR DESCRIPTION
Hello. I'm using node-resque module.

I found this errors when I throw string error in my code.
I think that retry plugin should support non-stacktrace error.

Thank you.

```
/Users/pine/project/Gabriel/node_modules/bluebird/js/release/async.js:61
        fn = function () { throw arg; };
                           ^

TypeError: Cannot read property 'split' of undefined
    at retry.saveLastError (/Users/pine/project/Gabriel/node_modules/node-resque/lib/plugins/retry.js:101:40)
    at /Users/pine/project/Gabriel/node_modules/node-resque/lib/plugins/retry.js:131:10
    at /Users/pine/project/Gabriel/node_modules/node-resque/lib/plugins/retry.js:78:16
    at tryCatcher (/Users/pine/project/Gabriel/node_modules/bluebird/js/release/util.js:16:23)
    at Promise.successAdapter [as _fulfillmentHandler0] (/Users/pine/project/Gabriel/node_modules/bluebird/js/release/nodeify.js:23:30)
    at Promise._settlePromise (/Users/pine/project/Gabriel/node_modules/bluebird/js/release/promise.js:564:21)
    at Promise._settlePromise0 (/Users/pine/project/Gabriel/node_modules/bluebird/js/release/promise.js:612:10)
    at Promise._settlePromises (/Users/pine/project/Gabriel/node_modules/bluebird/js/release/promise.js:691:18)
    at Async._drainQueue (/Users/pine/project/Gabriel/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/Users/pine/project/Gabriel/node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues (/Users/pine/project/Gabriel/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:649:20)
    at tryOnImmediate (timers.js:622:5)
    at processImmediate [as _immediateCallback] (timers.js:594:5)
```