### PR TITLE
fix call callback for stopMultiWorker before stop all workers

### DIFF
--- a/lib/multiWorker.js
+++ b/lib/multiWorker.js
@@ -29,6 +29,7 @@ var multiWorker = function (options, jobs) {
   self.eventLoopBlocked = true
   self.eventLoopDelay = Infinity
   self.eventLoopCheckCounter = 0
+  self.stopInProcess = false
 
   eventLoopDelay(
     self.options.maxEventLoopDelay,
@@ -106,20 +107,23 @@ multiWorker.prototype.checkWorkers = function (callback) {
       self.working = false
     }
 
-    if (self.running === false && self.workers.length > 0) { verb = '--' } else if (self.running === false && self.workers.length === 0) { verb = 'x' } else if (self.eventLoopBlocked && self.workers.length > self.options.minTaskProcessors) { verb = '-' } else if (self.eventLoopBlocked && self.workers.length === self.options.minTaskProcessors) { verb = 'x' } else if (!self.eventLoopBlocked && self.workers.length < self.options.minTaskProcessors) { verb = '+' } else if (
-      !self.eventLoopBlocked &&
-      self.workers.length < self.options.maxTaskProcessors &&
-      (
-        self.workers.length === 0 ||
-        workingCount / self.workers.length > 0.5
-      )
-    ) { verb = '+' } else if (
-      !self.eventLoopBlocked &&
-      self.workers.length > self.options.minTaskProcessors &&
-      workingCount / self.workers.length < 0.5
-    ) {
+    if (self.running === false && self.workers.length > 0) {
+      verb = '--'
+    } else if (self.running === false && self.workers.length === 0) {
+      verb = 'x'
+    } else if (self.eventLoopBlocked && self.workers.length > self.options.minTaskProcessors) {
       verb = '-'
-    } else { verb = 'x' }
+    } else if (self.eventLoopBlocked && self.workers.length === self.options.minTaskProcessors) {
+      verb = 'x'
+    } else if (!self.eventLoopBlocked && self.workers.length < self.options.minTaskProcessors) {
+      verb = '+'
+    } else if (!self.eventLoopBlocked && self.workers.length < self.options.maxTaskProcessors && (self.workers.length === 0 || (workingCount / self.workers.length > 0.5))) {
+      verb = '+'
+    } else if (!self.eventLoopBlocked && self.workers.length > self.options.minTaskProcessors && (workingCount / self.workers.length < 0.5)) {
+      verb = '-'
+    } else {
+      verb = 'x'
+    }
 
     if (verb === 'x') { return callback(null, verb, self.eventLoopDelay) }
 
@@ -132,6 +136,7 @@ multiWorker.prototype.checkWorkers = function (callback) {
     }
 
     if (verb === '--') {
+      self.stopInProcess = true
       var jobs = []
 
       var stopWorker = function (worker) {
@@ -150,6 +155,7 @@ multiWorker.prototype.checkWorkers = function (callback) {
       }
 
       async.parallel(jobs, function (error) {
+        self.stopInProcess = false
         self.workers = []
         callback(error, verb, self.eventLoopDelay)
       })
@@ -222,7 +228,7 @@ multiWorker.prototype.end = function (callback) {
 
 multiWorker.prototype.stopWait = function (callback) {
   var self = this
-  if (self.workers.length === 0 && self.working === false) {
+  if (self.workers.length === 0 && self.working === false && !self.stopInProcess) {
     clearTimeout(self.checkTimer)
     process.nextTick(function () {
       if (typeof callback === 'function') { callback() }


### PR DESCRIPTION
- [x] run standart check
- [x] run tests

In some cases `stop` callback for *multiWorker* called before all workers stopped.
It\`s happened through calling `self.workers.pop()` in `checkWorkers` method, and check `self.workers.length === 0` in `stopWait`.

PR fix this bug and refactor long condition line.
Related to issue for Actionhero - https://github.com/actionhero/actionhero/issues/1028