### PR TITLE
Allow empty namespace (and remove from generated key) to match Sidekiq default

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -108,6 +108,9 @@ connection.prototype.key = function () {
   var args
   args = (arguments.length >= 1 ? [].slice.call(arguments, 0) : [])
   args.unshift(this.options.namespace)
+  args = args.filter(function (e) {
+    return String(e).trim()
+  })
   return args.join(':')
 }
 

--- a/test/core/connection.js
+++ b/test/core/connection.js
@@ -60,4 +60,19 @@ describe('connection', function () {
       done()
     })
   })
+
+  it('removes empty namespace from generated key', function (done) {
+    var Connection = specHelper.NR.connection
+
+    var connectionDetails = specHelper.cleanConnectionDetails()
+    connectionDetails['namespace'] = ''
+
+    var connection = new Connection(connectionDetails)
+
+    connection.connect(function () {
+      connection.key('thing').should.equal('thing')
+      connection.end()
+      done()
+    })
+  })
 })


### PR DESCRIPTION
Although you can specify a namespace in Sidekiq, the default (and encouraged) behavior is to avoid using namespaces. This PR makes it possible to drop the default namespace by specifying an empty string in the connection config and then removing empty strings from the generated keys.

It may be a bit cleaner to allow users to specify `null` for the `namespace` option, but that required broader changes given the way the options are built up now. The easy route for this would be to just pass `null`s through (if object has key, assume the user knows what is "valid"). I felt like that may be confusing if someone accidentally specified `null` for something that should assume the default, but didn't feel like detangling the generic option build up for a single key (in this case, `namespace`).

That said, I'm open to suggestions if this quick-and-dirty approach is not preferred!