### PR TITLE
adjust windows cmd for pids to powershell

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -296,7 +296,7 @@ class Worker extends EventEmitter {
   async getPids () {
     let cmd
     if (process.platform === 'win32') {
-      cmd = 'for /f "usebackq tokens=2 skip=2" %i in (`tasklist /nh`) do @echo %i'
+      cmd = 'powershell.exe -command "Get-Process | select Id"'
     } else {
       cmd = 'ps -ef | awk \'{print $2}\''
     }


### PR DESCRIPTION
On different systems (especially azure) we've detected that tasklist.exe runs to errors, so no scheduler is started. 

Since powershell is on every windows system is available, this command is more convenient to get the process ids.