### PR TITLE
allow for empty namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Build Status](https://secure.travis-ci.org/taskrabbit/node-resque.png?branch=master)](http://travis-ci.org/taskrabbit/node-resque)
 
 ## Version Notes
-* ‼️ Version 6+ of Node Resque uses async/await.  There is no upgrade path from previous versions.  Node v8.0.0+ is required.
+* ‼️ Version 5+ of Node Resque uses async/await.  There is no upgrade path from previous versions.  Node v8.0.0+ is required.
 
 ## Usage
 

--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 - dropped support for fakeredis; you must use a redis connection which supports promises
 - async!!!
 - capitol names for all classes
-- plugin lifecycles are now cammel case: beforeEnqueue, afterEnqueue, beforePerform, afterPerform
+- plugin lifecycles are now camel case: beforeEnqueue, afterEnqueue, beforePerform, afterPerform
 - plugin lifecycle methods are now async methods, with no callback
 - plugins now inherit from NodeResque.Plugin
+- allow for empty/null namespaces (to match sidekiq's default)

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -81,6 +81,7 @@ class Connection extends EventEmitter {
     let args
     args = (arguments.length >= 1 ? [].slice.call(arguments, 0) : [])
     args.unshift(this.options.namespace)
+    args = args.filter((e) => { return String(e).trim() })
     return args.join(':')
   }
 }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -185,6 +185,7 @@ class Queue extends EventEmitter {
     for (var i = 0; i < keys.length; i++) {
       var k = keys[i]
       k = k.replace(this.connection.key(''), '')
+      if (k[0] === ':') { k = k.substr(1) }
       data[k] = values[i]
     }
 

--- a/test/core/connection.js
+++ b/test/core/connection.js
@@ -45,4 +45,13 @@ describe('connection', () => {
     connection.key('thing').should.equal(specHelper.namespace + ':thing')
     connection.end()
   })
+
+  it('removes empty namespace from generated key', async () => {
+    let connectionDetails = specHelper.cleanConnectionDetails()
+    connectionDetails['namespace'] = ''
+    let connection = new NodeResque.Connection(connectionDetails)
+    await connection.connect()
+    connection.key('thing').should.equal('thing')
+    connection.end()
+  })
 })


### PR DESCRIPTION
From the original PR (https://github.com/taskrabbit/node-resque/pull/210)

@conarro says: 

> Although you can specify a namespace in Sidekiq, the default (and encouraged) behavior is to avoid using namespaces. This PR makes it possible to drop the default namespace by specifying an empty string in the connection config and then removing empty strings from the generated keys.

