### PR TITLE
Check if job already exists in queue

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -61,10 +61,8 @@ class Queue extends EventEmitter {
     let rTimestamp = Math.round(timestamp / 1000) // assume timestamp is in ms
 
     let match = ('delayed:' + rTimestamp)
-    let members = await this.connection.redis.smembers(this.connection.key('timestamps:' + item))
-    for (let i in members) {
-      if (members[i] === match) { throw new Error('Job already enqueued at this time with same arguments') }
-    }
+    let foundMatch = await this.connection.redis.sismember(this.connection.key('timestamps:' + item), match)
+    if (foundMatch === 1) { throw new Error('Job already enqueued at this time with same arguments') }
 
     await this.connection.redis.rpush(this.connection.key('delayed:' + rTimestamp), item)
     await this.connection.redis.sadd(this.connection.key('timestamps:' + item), ('delayed:' + rTimestamp))


### PR DESCRIPTION
Instead of getting the full set (smembers), and iterating through it, just use sismember.