### PR TITLE
make it possible to use on the linux with busybox

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -297,7 +297,7 @@ class Worker extends EventEmitter {
     if (process.platform === 'win32') {
       cmd = 'powershell.exe -command "Get-Process | select Id"'
     } else {
-      cmd = 'ps -o pid='
+      cmd = 'ps -eo pid='
     }
 
     return new Promise((resolve, reject) => {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -297,7 +297,7 @@ class Worker extends EventEmitter {
     if (process.platform === 'win32') {
       cmd = 'powershell.exe -command "Get-Process | select Id"'
     } else {
-      cmd = 'ps -ef | awk \'{print $2}\''
+      cmd = 'ps -o pid='
     }
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
__prologue__

All the time I get the following in my actionhero–based project
```
...
cc1e9b62792b - info: [ worker ] cleaning old worker cc1e9b62792b:15+2:testQueue, (15)
cc1e9b62792b - info: [ worker ] cleaning old worker cc1e9b62792b:15+2:testQueue, (15)
cc1e9b62792b - info: [ worker ] cleaning old worker cc1e9b62792b:15+2:testQueue, (15)
cc1e9b62792b - info: [ worker ] cleaning old worker cc1e9b62792b:15+2:testQueue, (15)
cc1e9b62792b - info: [ worker ] cleaning old worker cc1e9b62792b:15+2:testQueue, (15)
...
```

__fix__

Fix the problem with the default full list in busybox ps.

PIDs are in the first column.

```
alpine:~# ps -ef
PID   USER     TIME   COMMAND
    1 root       0:07 /sbin/init
    2 root       0:00 [kthreadd]
    3 root       0:00 [ksoftirqd/0]
```