### PR TITLE
QueueLock plugin should clear lock when job is popped from queue not at job success

### DIFF
--- a/lib/plugins/QueueLock.js
+++ b/lib/plugins/QueueLock.js
@@ -18,7 +18,7 @@ class QueueLock extends NodeResque.Plugin {
     return true
   }
 
-  async afterPerform () {
+  async beforePerform () {
     let key = this.key()
     await this.queueObject.connection.redis.del(key)
     return true


### PR DESCRIPTION
solves https://github.com/taskrabbit/node-resque/issues/226

The QueueLock plugin will now properly release the lock on a job+args when the job is popped from the queue by a worker rather than on the job's success.  This more closely matches the plugin's name, in that only one job with the same args can be in the queue at a time... a job being worked on is not in the queue. 