### PR TITLE
Implements the concept of unique tasks via sorted sets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/*
 .DS_Store
 npm-debug.log
 dump.rdb
+.idea/*

--- a/lib/multiWorker.js
+++ b/lib/multiWorker.js
@@ -16,6 +16,7 @@ class MultiWorker extends EventEmitter {
       checkTimeout: 500,
       maxEventLoopDelay: 10,
       toDisconnectProcessors: true,
+      tasksAreUnique: true,
       name: os.hostname()
     }
 
@@ -59,7 +60,8 @@ class MultiWorker extends EventEmitter {
       connection: this.options.connection,
       queues: this.options.queues,
       timeout: this.options.timeout,
-      name: this.options.name + ':' + process.pid + '+' + id
+      name: this.options.name + ':' + process.pid + '+' + id,
+      tasksAreUnique: this.options.tasksAreUnique
     }, this.jobs)
 
     worker.id = id

--- a/lib/plugins/QueueLock.js
+++ b/lib/plugins/QueueLock.js
@@ -8,7 +8,6 @@ class QueueLock extends NodeResque.Plugin {
     let timeout = now + this.lockTimeout() + 1
     let set = await this.queueObject.connection.redis.setnx(key, timeout)
     if (set === true || set === 1) { return true }
-
     let redisTimeout = await this.queueObject.connection.redis.get(key)
     redisTimeout = parseInt(redisTimeout)
     if (now <= redisTimeout) { return false }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -43,12 +43,17 @@ class Queue extends EventEmitter {
     if (!args) { args = [] }
     args = arrayify(args)
     let job = this.jobs[func]
+    let timestamp = new Date().getTime()
 
     let toRun = await PluginRunner.RunPlugins(this, 'beforeEnqueue', func, q, job, args)
     if (toRun === false) { return toRun }
 
     await this.connection.redis.sadd(this.connection.key('queues'), q)
-    await this.connection.redis.rpush(this.connection.key('queue', q), this.encode(q, func, args))
+    if (this.options.tasksAreUnique) {
+      await this.connection.redis.zadd(this.connection.key('queue', q), timestamp, this.encode(q, func, args))
+    } else {
+      await this.connection.redis.rpush(this.connection.key('queue', q), this.encode(q, func, args))
+    }
     await PluginRunner.RunPlugins(this, 'afterEnqueue', func, q, job, args)
     return toRun
   }
@@ -84,13 +89,25 @@ class Queue extends EventEmitter {
   }
 
   async length (q) {
-    return this.connection.redis.llen(this.connection.key('queue', q))
+    if (this.options.tasksAreUnique) {
+      return this.connection.redis.zcard(this.connection.key('queue', q))
+    } else {
+      return this.connection.redis.llen(this.connection.key('queue', q))
+    }
   }
 
   async del (q, func, args, count) {
     if (!args) { args = [] }
     if (!count) { count = 0 }
     args = arrayify(args)
+    if (this.options.tasksAreUnique) {
+      // Is this supposed to be deleting the queue itself, or removing a specific amount of elements from
+      // the set that match the given key.  I'm going with the assumption we want to remove a speciific
+      // action from the queue.  If we want to delete the entire set then we can amend to below:
+      // let len = await this.length(q)
+      // return this.connection.redis.zremrangebyrank(this.connection.key('queue', q), 0, len)
+      return this.connection.redis.zrem(this.connection.key('queue', q), this.encode(q, func, args))
+    }
     return this.connection.redis.lrem(this.connection.key('queue', q), count, this.encode(q, func, args))
   }
 
@@ -148,9 +165,17 @@ class Queue extends EventEmitter {
   }
 
   async queued (q, start, stop) {
-    let items = await this.connection.redis.lrange(this.connection.key('queue', q), start, stop)
-    let tasks = items.map(function (i) { return JSON.parse(i) })
-    return tasks
+    let items = null
+    let tasks = null
+    if (this.options.tasksAreUnique) {
+      items = await this.connection.redis.zrange(this.connection.key('queue', q), start, stop)
+      tasks = items.map(function (i) { return JSON.parse(i) })
+      return tasks
+    } else {
+      items = await this.connection.redis.lrange(this.connection.key('queue', q), start, stop)
+      tasks = items.map(function (i) { return JSON.parse(i) })
+      return tasks
+    }
   }
 
   async allDelayed () {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -14,7 +14,8 @@ class Scheduler extends EventEmitter {
     const defaults = {
       timeout: 5000,                          // in ms
       masterLockTimeout: 60 * 3,              // in seconds
-      name: os.hostname() + ':' + process.pid // assumes only one worker per node process
+      name: os.hostname() + ':' + process.pid, // assumes only one worker per node process
+      tasksAreUnique: true
     }
 
     for (let i in defaults) {
@@ -27,7 +28,7 @@ class Scheduler extends EventEmitter {
     this.running = false
     this.processing = false
 
-    this.queue = new Queue({connection: options.connection}, jobs)
+    this.queue = new Queue({connection: options.connection, tasksAreUnique: options.tasksAreUnique}, jobs)
     this.queue.on('error', (error) => { this.emit('error', error) })
   }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -22,7 +22,8 @@ class Worker extends EventEmitter {
       name: os.hostname() + ':' + process.pid, // assumes only one worker per node process
       queues: '*',
       timeout: 5000,
-      looping: true
+      looping: true,
+      tasksAreUnique: true
     }
 
     for (let i in defaults) {
@@ -40,7 +41,7 @@ class Worker extends EventEmitter {
     this.working = false
     this.job = null
 
-    this.queueObject = new Queue({connection: options.connection}, this.jobs)
+    this.queueObject = new Queue({connection: options.connection, tasksAreUnique: options.tasksAreUnique}, this.jobs)
     this.queueObject.on('error', (error) => { this.emit('error', error) })
   }
 
@@ -76,7 +77,6 @@ class Worker extends EventEmitter {
 
     await this.untrack(this.name, this.stringQueues())
     await this.queueObject.end()
-    this.emit('end', new Date())
   }
 
   async poll (nQueue) {
@@ -87,12 +87,14 @@ class Worker extends EventEmitter {
     this.emit('poll', this.queue)
 
     if (this.queue === null || this.queue === undefined) {
+      console.log('checking for queues')
       await this.checkQueues()
       await this.pause()
       return null
     }
 
     if (this.working === true) {
+      console.log('doing work on queue: ', this.queue)
       let error = new Error('refusing to get new job, already working')
       this.emit('error', error, this.queue)
       return null
@@ -101,7 +103,17 @@ class Worker extends EventEmitter {
     this.working = true
 
     try {
-      let encodedJob = await this.connection.redis.lpop(this.connection.key('queue', this.queue))
+      let encodedJob = null
+      if (this.options.tasksAreUnique) {
+        // zpop is essentially done in two prongs, get the element by range 0,0 and if it exists then remove it.
+        let jobs = await this.connection.redis.zrange(this.connection.key('queue', this.queue), 0, 0)
+        if (jobs && jobs.length > 0) {
+          await this.connection.redis.zrem(this.connection.key('queue', this.queue), jobs[0])
+          encodedJob = jobs[0]
+        }
+      } else {
+        encodedJob = await this.connection.redis.lpop(this.connection.key('queue', this.queue))
+      }
       if (encodedJob) {
         let currentJob = JSON.parse(encodedJob.toString())
         if (this.options.looping) {
@@ -277,7 +289,6 @@ class Worker extends EventEmitter {
   async workerCleanup () {
     let pids = await this.getPids()
     let workers = await this.connection.redis.smembers(this.connection.key('workers'))
-
     for (let i in workers) {
       let worker = workers[i]
       let parts = worker.split(':')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-resque",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -356,11 +356,6 @@
         "isarray": "1.0.0"
       }
     },
-    "double-ended-queue": {
-      "version": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
-      "dev": true
-    },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
@@ -702,11 +697,43 @@
       "dev": true
     },
     "fakeredis": {
-      "version": "https://registry.npmjs.org/fakeredis/-/fakeredis-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fakeredis/-/fakeredis-2.0.0.tgz",
       "integrity": "sha1-dS+4MoGazjG+iGaM8TWNbxQ4r8A=",
       "dev": true,
       "requires": {
-        "redis": "https://registry.npmjs.org/redis/-/redis-2.6.0-0.tgz"
+        "redis": "2.6.0-0"
+      },
+      "dependencies": {
+        "double-ended-queue": {
+          "version": "2.1.0-0",
+          "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+          "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
+          "dev": true
+        },
+        "redis": {
+          "version": "2.6.0-0",
+          "resolved": "https://registry.npmjs.org/redis/-/redis-2.6.0-0.tgz",
+          "integrity": "sha1-c/Z03T5Uo6dnA9HtJga05gC+B20=",
+          "dev": true,
+          "requires": {
+            "double-ended-queue": "2.1.0-0",
+            "redis-commands": "1.3.1",
+            "redis-parser": "1.3.0"
+          }
+        },
+        "redis-commands": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
+          "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs=",
+          "dev": true
+        },
+        "redis-parser": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-1.3.0.tgz",
+          "integrity": "sha1-gG6+e7+3005NfB6e8oLvz60EEmo=",
+          "dev": true
+        }
       }
     },
     "fast-levenshtein": {
@@ -1671,24 +1698,9 @@
         "resolve": "1.4.0"
       }
     },
-    "redis": {
-      "version": "https://registry.npmjs.org/redis/-/redis-2.6.0-0.tgz",
-      "integrity": "sha1-c/Z03T5Uo6dnA9HtJga05gC+B20=",
-      "dev": true,
-      "requires": {
-        "double-ended-queue": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-        "redis-commands": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
-        "redis-parser": "https://registry.npmjs.org/redis-parser/-/redis-parser-1.3.0.tgz"
-      }
-    },
     "redis-commands": {
       "version": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.3.1.tgz",
       "integrity": "sha1-gdgm9F+pyLIBH0zXoP5ZfSQdRCs="
-    },
-    "redis-parser": {
-      "version": "https://registry.npmjs.org/redis-parser/-/redis-parser-1.3.0.tgz",
-      "integrity": "sha1-gG6+e7+3005NfB6e8oLvz60EEmo=",
-      "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -1887,15 +1899,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -1905,6 +1908,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/test/core/multiWorker.js
+++ b/test/core/multiWorker.js
@@ -48,7 +48,7 @@ const jobs = {
 describe('multiWorker', function () {
   before(async () => {
     await specHelper.connect()
-    queue = new NodeResque.Queue({connection: specHelper.cleanConnectionDetails(), queue: specHelper.queue})
+    queue = new NodeResque.Queue({connection: specHelper.cleanConnectionDetails(), queue: specHelper.queue, tasksAreUnique: specHelper.tasksAreUnique})
     await queue.connect()
   })
 
@@ -60,7 +60,8 @@ describe('multiWorker', function () {
       minTaskProcessors: minTaskProcessors,
       maxTaskProcessors: maxTaskProcessors,
       queues: [specHelper.queue],
-      toDisconnectProcessors: toDisconnectProcessors
+      toDisconnectProcessors: toDisconnectProcessors,
+      tasksAreUnique: specHelper.tasksAreUnique
     }, jobs)
 
     await multiWorker.end()
@@ -86,7 +87,7 @@ describe('multiWorker', function () {
 
     var i = 0
     while (i < 100) {
-      await queue.enqueue(specHelper.queue, 'slowSleepJob', [])
+      await queue.enqueue(specHelper.queue, 'slowSleepJob', [i]) // argument needs to be supplied for a non-unique job to pass the test :)
       i++
     }
 

--- a/test/plugins/custom_plugins.js
+++ b/test/plugins/custom_plugins.js
@@ -15,7 +15,7 @@ describe('plugins', () => {
         }
       }
 
-      const queue = new NodeResque.Queue({connection: specHelper.cleanConnectionDetails(), queue: specHelper.queue}, jobs)
+      const queue = new NodeResque.Queue({connection: specHelper.cleanConnectionDetails(), queue: specHelper.queue, tasksAreUnique: specHelper.tasksAreUnique}, jobs)
 
       await queue.connect()
       let enqueueResponse = await queue.enqueue(specHelper.queue, 'myJob', [1, 2])

--- a/test/plugins/delayedQueueLock.js
+++ b/test/plugins/delayedQueueLock.js
@@ -30,7 +30,7 @@ describe('plugins', () => {
   before(async () => {
     await specHelper.connect()
     await specHelper.cleanup()
-    queue = new NodeResque.Queue({connection: specHelper.cleanConnectionDetails(), queue: specHelper.queue}, jobs)
+    queue = new NodeResque.Queue({connection: specHelper.cleanConnectionDetails(), queue: specHelper.queue, tasksAreUnique: specHelper.tasksAreUnique}, jobs)
     queue.connect()
   })
 

--- a/test/plugins/jobLock.js
+++ b/test/plugins/jobLock.js
@@ -24,7 +24,7 @@ describe('plugins', () => {
   before(async () => {
     await specHelper.connect()
     await specHelper.cleanup()
-    queue = new NodeResque.Queue({connection: specHelper.cleanConnectionDetails(), queue: specHelper.queue}, jobs)
+    queue = new NodeResque.Queue({connection: specHelper.cleanConnectionDetails(), queue: specHelper.queue, tasksAreUnique: specHelper.tasksAreUnique}, jobs)
     await queue.connect()
   })
 
@@ -34,8 +34,8 @@ describe('plugins', () => {
 
   describe('jobLock', () => {
     it('will not lock jobs since arg objects are different', async () => {
-      worker1 = new NodeResque.Worker({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout, queues: specHelper.queue}, jobs)
-      worker2 = new NodeResque.Worker({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout, queues: specHelper.queue}, jobs)
+      worker1 = new NodeResque.Worker({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout, queues: specHelper.queue, tasksAreUnique: specHelper.tasksAreUnique}, jobs)
+      worker2 = new NodeResque.Worker({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout, queues: specHelper.queue, tasksAreUnique: specHelper.tasksAreUnique}, jobs)
 
       worker1.on('error', (error) => { throw error })
       worker2.on('error', (error) => { throw error })
@@ -94,7 +94,7 @@ describe('plugins', () => {
           }
         }
 
-        worker1 = new NodeResque.Worker({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout, queues: specHelper.queue}, functionJobs)
+        worker1 = new NodeResque.Worker({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout, queues: specHelper.queue, tasksAreUnique: specHelper.tasksAreUnique}, functionJobs)
         worker1.on('error', (error) => { throw error })
         await worker1.connect()
         await queue.enqueue(specHelper.queue, 'jobLockAdd', [1, 2])
@@ -104,8 +104,8 @@ describe('plugins', () => {
 
     it('will not run 2 jobs with the same args at the same time', async () => {
       let count = 0
-      worker1 = new NodeResque.Worker({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout, queues: specHelper.queue}, jobs)
-      worker2 = new NodeResque.Worker({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout, queues: specHelper.queue}, jobs)
+      worker1 = new NodeResque.Worker({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout, queues: specHelper.queue, tasksAreUnique: specHelper.tasksAreUnique}, jobs)
+      worker2 = new NodeResque.Worker({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout, queues: specHelper.queue, tasksAreUnique: specHelper.tasksAreUnique}, jobs)
 
       worker1.on('error', (error) => { throw error })
       worker2.on('error', (error) => { throw error })
@@ -142,8 +142,8 @@ describe('plugins', () => {
     })
 
     it('will run 2 jobs with the different args at the same time', async () => {
-      worker1 = new NodeResque.Worker({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout, queues: specHelper.queue}, jobs)
-      worker2 = new NodeResque.Worker({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout, queues: specHelper.queue}, jobs)
+      worker1 = new NodeResque.Worker({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout, queues: specHelper.queue, tasksAreUnique: specHelper.tasksAreUnique}, jobs)
+      worker2 = new NodeResque.Worker({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout, queues: specHelper.queue, tasksAreUnique: specHelper.tasksAreUnique}, jobs)
 
       worker1.on('error', (error) => { throw error })
       worker2.on('error', (error) => { throw error })

--- a/test/plugins/noop.js
+++ b/test/plugins/noop.js
@@ -33,8 +33,8 @@ describe('plugins', () => {
     before(async () => {
       await specHelper.connect()
       await specHelper.cleanup()
-      queue = new NodeResque.Queue({connection: specHelper.cleanConnectionDetails(), queue: specHelper.queue}, jobs)
-      scheduler = new NodeResque.Scheduler({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout})
+      queue = new NodeResque.Queue({connection: specHelper.cleanConnectionDetails(), queue: specHelper.queue, tasksAreUnique: specHelper.tasksAreUnique}, jobs)
+      scheduler = new NodeResque.Scheduler({connection: specHelper.cleanConnectionDetails(), timeout: specHelper.timeout, tasksAreUnique: specHelper.tasksAreUnique})
       await scheduler.connect()
       scheduler.start()
       await queue.connect()
@@ -52,7 +52,8 @@ describe('plugins', () => {
       let worker = new NodeResque.Worker({
         connection: specHelper.cleanConnectionDetails(),
         timeout: specHelper.timeout,
-        queues: specHelper.queue
+        queues: specHelper.queue,
+        tasksAreUnique: specHelper.tasksAreUnique
       }, jobs)
 
       await new Promise(async (resolve) => {
@@ -60,7 +61,7 @@ describe('plugins', () => {
 
         worker.on('success', async () => {
           loggedErrors.length.should.equal(0)
-          let length = await specHelper.redis.llen('resque_test:failed')
+          let length = await specHelper.redis.llen(specHelper.namespace + ':failed')
           length.should.equal(0)
           await worker.end()
           resolve()
@@ -80,13 +81,14 @@ describe('plugins', () => {
       let worker = new NodeResque.Worker({
         connection: specHelper.cleanConnectionDetails(),
         timeout: specHelper.timeout,
-        queues: specHelper.queue
+        queues: specHelper.queue,
+        tasksAreUnique: specHelper.tasksAreUnique
       }, jobs)
 
       await new Promise(async (resolve) => {
         worker.on('success', async () => {
           loggedErrors.length.should.equal(1)
-          let length = await specHelper.redis.llen('resque_test:failed')
+          let length = await specHelper.redis.llen(specHelper.namespace + ':failed')
           length.should.equal(0)
           await worker.end()
           resolve()

--- a/test/plugins/queueLock.js
+++ b/test/plugins/queueLock.js
@@ -26,7 +26,7 @@ describe('plugins', () => {
     before(async () => {
       await specHelper.connect()
       await specHelper.cleanup()
-      queue = new NodeResque.Queue({connection: specHelper.cleanConnectionDetails(), queue: specHelper.queue}, jobs)
+      queue = new NodeResque.Queue({connection: specHelper.cleanConnectionDetails(), queue: specHelper.queue, tasksAreUnique: specHelper.tasksAreUnique}, jobs)
       await queue.connect()
     })
 
@@ -58,7 +58,8 @@ describe('plugins', () => {
         worker = new NodeResque.Worker({
           connection: specHelper.cleanConnectionDetails(),
           timeout: specHelper.timeout,
-          queues: specHelper.queue
+          queues: specHelper.queue,
+          tasksAreUnique: specHelper.tasksAreUnique
         }, jobs)
 
         worker.on('error', (error) => { throw error })


### PR DESCRIPTION
I'm not sure if you would be interested in this, but at work we needed to support the concept of unique actions.  In that once one item is in the queue it shouldn't be able to be published again until the current action completes (we have two separate queue instances for unique/non-unique events)

Our current system was built using PHP and MySQL (eww) so I did some research and was torn between node-resque and kue.  I decided to use node-resque after watching a few of your presentations on YouTube.

I'd spent a couple of days before I realised that node-resque does not support unique actions out of the box and instead of swapping over to kue and binning a bunch of work I decided to try and extend this library to support them.  It does so through the introduction of a new config parameter `tasksAreUnique` which is false by default and will yield previous behaviour.   If `tasksAreUnique` is set to true then the job queue will be composed of Redis sorted-sets instead of lists, this maintains an ordered priority queue (unless we give developers the option to provide the NX command and escalate the action priority if it is re-published to the queue by increasing its SCORE)

No worries if you're not interested in this, I just thought I'd share :)

Thanks again for all of your hard work on this, it rocks!