### PR TITLE
invert test for redis conneciton logic

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -72,7 +72,7 @@ class Connection extends EventEmitter {
     })
 
     // Only disconnect if we established the redis connection on our own.
-    if (!this.options.redis) {
+    if (this.redis) {
       if (typeof this.redis.disconnect === 'function') { this.redis.disconnect() } else { this.redis.quit() }
     }
   }


### PR DESCRIPTION
I'm in the process of updating node-queue-bus https://github.com/queue-bus/node-queue-bus to take advantage of the move to async/await. During my thrashing I came across a situation where `this.options.redis && this.redis` weren't instantiated, but the below code then immediately tries to disconnect with an object that's undefined. I think the `!` at the front of the if statement is incorrect, but since I'm still mid-swing at my changes not 100% sure I haven't mucked something up. I also moved to `this.redis` in favor of `this.options.redis` since it's the reference used inside the conditional.