### PR TITLE
Use redis recursive scan with match instead of keys to reduce pressure on redis

### DIFF
--- a/__tests__/core/connection.js
+++ b/__tests__/core/connection.js
@@ -69,11 +69,9 @@ describe('connection', () => {
       await Promise.all(
         new Array(25).fill(0).map((v, i) => i + 1).map(async v => {
           await connection.redis.set(`test-key${v}`, v.toString())
-        })
-      )
-      await Promise.all(
-        new Array(5).fill(0).map((v, i) => i + 1).map(async v => {
-          await connection.redis.set(`test-not-key${v}`, v.toString())
+          if (v <= 5) {
+            await connection.redis.set(`test-not-key${v}`, v.toString())
+          }
         })
       )
 

--- a/__tests__/core/connection.js
+++ b/__tests__/core/connection.js
@@ -64,6 +64,39 @@ describe('connection', () => {
       prefixedRedis.quit()
     })
 
+    test('getKeys returns appropriate keys based on matcher given', async () => {
+      // seed the DB with keys to test with
+      await Promise.all(
+        new Array(25).fill(0).map((v, i) => i + 1).map(async v => {
+          await connection.redis.set(`test-key${v}`, v.toString())
+        })
+      )
+      await Promise.all(
+        new Array(5).fill(0).map((v, i) => i + 1).map(async v => {
+          await connection.redis.set(`test-not-key${v}`, v.toString())
+        })
+      )
+
+      // sanity checks to confirm keys above are set and exist
+      expect(await connection.redis.get('test-key1')).toBe('1')
+      expect(await connection.redis.get('test-key20')).toBe('20')
+      expect(await connection.redis.get('test-not-key1')).toBe('1')
+      expect(await connection.redis.get('test-not-key5')).toBe('5')
+
+      const foundKeys = await connection.getKeys('test-key*')
+
+      expect(foundKeys.length).toBe(25)
+      expect(foundKeys).toContain('test-key1')
+      expect(foundKeys).toContain('test-key5')
+      expect(foundKeys).toContain('test-key20')
+      expect(foundKeys).toContain('test-key25')
+      expect(foundKeys).not.toContain('test-key50')
+      expect(foundKeys).not.toContain('test-not-key1')
+      expect(foundKeys).not.toContain('test-not-key3')
+      expect(foundKeys).not.toContain('test-not-key5')
+      expect(foundKeys).not.toContain('test-not-key50')
+    })
+
     test('keys built with the default namespace are correct', () => {
       expect(connection.key('thing')).toBe(`resque-test-${db}:thing`)
       expect(prefixedConnection.key('thing')).toBe(`resque-test-${db}:thing`)

--- a/__tests__/core/connection.js
+++ b/__tests__/core/connection.js
@@ -80,7 +80,7 @@ describe('connection', () => {
       expect(result).toBe('abc123')
       expect(prefixedResult).toBe('abc123')
 
-      const keys = await connection.redis.keys('*')
+      const keys = await connection.getKeys('*')
       expect(keys).toContain(`resque-test-${db}:testPrefixKey`)
       expect(keys).toContain(`customNamespace:resque-test-${db}:testPrefixKey`)
     })

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -70,6 +70,23 @@ class Connection extends EventEmitter {
     this.redis.on('end', this.listeners.end)
   }
 
+  async getKeys (match, keysAry = [], cursor = 0) {
+    if (this.redis && typeof this.redis.scan === 'function') {
+      const [ newCursor, matches ] = await this.redis.scan(cursor, 'match', match)
+      if (matches && matches.length > 0) {
+        keysAry = keysAry.concat(matches)
+      }
+
+      if (newCursor === '0') {
+        return keysAry
+      }
+
+      return this.getKeys(match, keysAry, newCursor)
+    }
+
+    this.emit('error', new Error('You must establish a connection to redis before running the keys command.'))
+  }
+
   end () {
     this.connected = false
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -84,7 +84,7 @@ class Connection extends EventEmitter {
       return this.getKeys(match, keysAry, newCursor)
     }
 
-    this.emit('error', new Error('You must establish a connection to redis before running the keys command.'))
+    this.emit('error', new Error('You must establish a connection to redis before running the getKeys command.'))
   }
 
   end () {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -131,7 +131,7 @@ class Queue extends EventEmitter {
 
   async timestamps () {
     let results = []
-    let timestamps = await this.connection.redis.keys(this.connection.key('delayed:*'))
+    let timestamps = await this.connection.getKeys(this.connection.key('delayed:*'))
     timestamps.forEach((timestamp) => {
       let parts = timestamp.split(':')
       results.push(parseInt(parts[(parts.length - 1)]) * 1000)
@@ -172,10 +172,10 @@ class Queue extends EventEmitter {
     let data = {}
     let _keys
 
-    _keys = await this.connection.redis.keys(this.connection.key('lock:*'))
+    _keys = await this.connection.getKeys(this.connection.key('lock:*'))
     keys = keys.concat(_keys)
 
-    _keys = await this.connection.redis.keys(this.connection.key('workerslock:*'))
+    _keys = await this.connection.getKeys(this.connection.key('workerslock:*'))
     keys = keys.concat(_keys)
 
     if (keys.length === 0) { return data }
@@ -325,7 +325,7 @@ class Queue extends EventEmitter {
 
   async stats () {
     let data = {}
-    let keys = await this.connection.redis.keys(this.connection.key('stat:*'))
+    let keys = await this.connection.getKeys(this.connection.key('stat:*'))
     if (keys.length === 0) { return data }
 
     let values = await this.connection.redis.mget(keys)

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -193,7 +193,7 @@ class Scheduler extends EventEmitter {
   async checkStuckWorkers () {
     if (!this.options.stuckWorkerTimeout) { return }
 
-    const keys = await this.connection.redis.keys(this.connection.key('worker', 'ping', '*'))
+    const keys = await this.connection.getKeys(this.connection.key('worker', 'ping', '*'))
     const payloads = await Promise.all(keys.map(async (k) => {
       return JSON.parse(await this.connection.redis.get(k))
     }))


### PR DESCRIPTION
Resolves #263 

I didn't write any new tests since based on a quick review the current test coverage should catch any issues that exist with the new `connection.getKeys`. I also updated an existing test to use the new method as well. All places in the repo using `connection.redis.keys` should now use `connection.getKeys` which uses recursive scan instead of keys.