### PR TITLE
Graceful stop multiworker

### DIFF
--- a/lib/multiWorker.js
+++ b/lib/multiWorker.js
@@ -123,11 +123,15 @@ class MultiWorker extends EventEmitter {
 
     if (verb === '--') {
       this.stopInProcess = true
-      for (let i in this.workers) {
-        let worker = this.workers[i]
-        await worker.end()
-        await this.cleanupWorker(worker)
-      }
+      await Promise.all(
+        this.workers.reduce(
+          (promises, worker) => promises.concat(
+            worker.end()
+              .then(() => this.cleanupWorker(worker))
+          ),
+          []
+        )
+      );
 
       this.stopInProcess = false
       this.workers = []


### PR DESCRIPTION
In current implementation workers stop sequentially one after another and until each of them stopped, the rest of workers continue to fetch jobs from queue. That cause some issues - as a developer I expect that not a single job fetched after `multiWorker.stop()` call.
I propose to send stop signal to all workers simultaneously to prevent unwanted jobs fetching.