### PR TITLE
Prevent error on worker stop

### DIFF
--- a/lib/plugins/Retry.js
+++ b/lib/plugins/Retry.js
@@ -36,7 +36,7 @@ class Retry extends NodeResque.Plugin {
 
     await this.queueObject.enqueueIn(nextTryDelay, this.queue, this.func, this.args)
 
-    this.job.args = this.args;
+    this.job.args = this.args
     this.worker.emit('reEnqueue', this.queue, this.job, {
       delay: nextTryDelay,
       remaningAttempts: remaning,

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -38,6 +38,9 @@ class Worker extends EventEmitter {
     this.working = false
     this.job = null
     this.pingTimer = null
+    this.connection = {
+      connected: false
+    }
 
     this.queueObject = new Queue({ connection: options.connection }, this.jobs)
     this.queueObject.on('error', (error) => { this.emit('error', error) })


### PR DESCRIPTION
We've found this error in our application logs:
`"TypeError: Cannot read property 'connected' of undefined
    at Worker.end (/opt/nodejs/dataaggregator/node_modules/node-resque/lib/worker.js:78:25)`
During investigation I found out that `this.connection` might be uninitialized at the moment when `worker.end()` method called. This causes error at line:
`if (this.connection.connected === true || this.connection.connected === undefined || this.connection.connected === null)`
Inside this block method `this.untrack()` called where check of property `connection` does exists:
`if (!this.connection || !this.connection.redis) { return }`
So I propose to initialize property `connection` in the worker's constructor