### PR TITLE
Change the way custom modules are referenced

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ const jobs = {
 ```javascript
 var jobs = {
   "add": {
-    plugins: [ require('Myplugin') ],
+    plugins: [ require('Myplugin').Myplugin ],
     pluginOptions: {
       MyPlugin: { thing: 'stuff' },
     },


### PR DESCRIPTION
Neither the example in Reamde.md nor the predefined plugins have constrcturs. Thus just copying one of the predefined plugins and requiring them in the way as described in readme doesn't work and throws 

> Error: Plugin must be the constructor name or an object

Therefore you need to explicitely pass a conrete function to PluginRunner.

However imho a better solution would be to update the predefined modules.