### PR TITLE
Add Atomic Scheduler Master Lock

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -118,9 +118,8 @@ class Scheduler extends EventEmitter {
     const masterKey = this.masterKey()
     if (!this.connection || !this.connection.redis) { return }
 
-    let lockedByMe = await this.connection.redis.setnx(masterKey, this.options.name)
+    let lockedByMe = await this.connection.redis.set(masterKey, this.options.name, 'NX', 'EX', this.options.masterLockTimeout)
     if (lockedByMe === true || lockedByMe === 1) {
-      await this.connection.redis.expire(masterKey, this.options.masterLockTimeout)
       return true
     }
 


### PR DESCRIPTION
Make setting the scheduler master lock and setting the expiration atomic. The `SET` command allows passing both an expiration and specifying to only set if the key doesn't exist.

Fixes #281 