### PR TITLE
Fix Atomic JobLock Key Setting

### DIFF
--- a/lib/plugins/JobLock.js
+++ b/lib/plugins/JobLock.js
@@ -6,9 +6,9 @@ class JobLock extends NodeResque.Plugin {
     let key = this.key()
     let now = Math.round(new Date().getTime() / 1000)
     let timeout = now + this.lockTimeout() + 1
-    let setCallback = await this.queueObject.connection.redis.setnx(key, timeout)
-    if (setCallback === true || setCallback === 1) {
-      await this.queueObject.connection.redis.expire(key, this.lockTimeout())
+
+    let lockedByMe = await this.queueObject.connection.redis.set(key, timeout, 'NX', 'EX', this.lockTimeout());
+    if (lockedByMe === true || lockedByMe === 1) {
       return true
     } else {
       await this.reEnqueue()


### PR DESCRIPTION
Similar to #283 which made the scheduler atomically get its lock, have
the JobLock plugin atomically get its lock so that a crash doesn't cause
the lock to be held forever.