### PR TITLE
Fix Response Value for Atomic Locks

### DIFF
--- a/lib/plugins/JobLock.js
+++ b/lib/plugins/JobLock.js
@@ -7,8 +7,8 @@ class JobLock extends NodeResque.Plugin {
     let now = Math.round(new Date().getTime() / 1000)
     let timeout = now + this.lockTimeout() + 1
 
-    let lockedByMe = await this.queueObject.connection.redis.set(key, timeout, 'NX', 'EX', this.lockTimeout());
-    if (lockedByMe === true || lockedByMe === 1) {
+    let lockedByMe = await this.queueObject.connection.redis.set(key, timeout, 'NX', 'EX', this.lockTimeout())
+    if (lockedByMe === 'OK') {
       return true
     } else {
       await this.reEnqueue()

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -119,7 +119,7 @@ class Scheduler extends EventEmitter {
     if (!this.connection || !this.connection.redis) { return }
 
     let lockedByMe = await this.connection.redis.set(masterKey, this.options.name, 'NX', 'EX', this.options.masterLockTimeout)
-    if (lockedByMe === true || lockedByMe === 1) {
+    if (lockedByMe === 'OK') {
       return true
     }
 


### PR DESCRIPTION
Unfortunately, the return values of `set` are different than `setnx`, which means that previous changes to set locks atomically are completely broken. The return value for `set` is `OK` upon success instead of `1`. This PR fixes this issue.