### PR TITLE
update connection logic to always await a test key write to ensure that the connection is ready before returning

### DIFF
--- a/__tests__/core/scheduler.js
+++ b/__tests__/core/scheduler.js
@@ -30,13 +30,13 @@ describe('scheduler', () => {
       scheduler.on('poll', () => { throw new Error('Should not emit poll') })
       scheduler.on('master', () => { throw new Error('Should not emit master') })
 
-      await scheduler.connect()
-
       scheduler.on('error', async (error) => {
         expect(error.message).toMatch(/ENOTFOUND|ETIMEDOUT/)
         await scheduler.end()
         done()
       })
+
+      scheduler.connect()
     }, 30 * 1000)
 
     describe('locking', () => {

--- a/__tests__/core/worker.js
+++ b/__tests__/core/worker.js
@@ -60,13 +60,13 @@ describe('worker', () => {
 
     const worker = new NodeResque.Worker({ connection: connectionDetails, timeout: specHelper.timeout, queues: specHelper.queue })
 
-    await worker.connect()
-
     worker.on('error', async (error) => {
       expect(error.message).toMatch(/ENOTFOUND|ETIMEDOUT/)
       await worker.end()
       done()
     })
+
+    worker.connect()
   }, 30 * 1000)
 
   describe('performInline', () => {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -26,8 +26,7 @@ class Connection extends EventEmitter {
   }
 
   async connect () {
-    if (this.options.redis) {
-      this.redis = this.options.redis
+    const connectionTest = async () => {
       try {
         await this.redis.set(this.key('connection_test_key'), 'ok')
         const data = await this.redis.get(this.key('connection_test_key'))
@@ -37,6 +36,11 @@ class Connection extends EventEmitter {
         this.connected = false
         this.emit('error', error)
       }
+    }
+
+    if (this.options.redis) {
+      this.redis = this.options.redis
+      await connectionTest()
     } else {
       if (this.options.pkg === 'ioredis') {
         const Pkg = require('ioredis')
@@ -46,29 +50,15 @@ class Connection extends EventEmitter {
         const Pkg = require(this.options.pkg)
         this.redis = Pkg.createClient(this.options.port, this.options.host, this.options.options)
       }
-
-      this.listeners.connect = async () => {
-        if (this.connected === true) {
-          // nothing to do here; this is a reconnect
-        } else {
-          try {
-            await this.redis.select(this.options.database)
-            this.connected = true
-          } catch (error) {
-            this.connected = false
-            this.emit('error', error)
-          }
-        }
-      }
-
-      this.redis.on('connect', this.listeners.connect)
     }
 
     this.listeners.error = (error) => { this.emit('error', error) }
-    this.redis.on('error', this.listeners.error)
-
     this.listeners.end = () => { this.connected = false }
+    this.redis.on('error', this.listeners.error)
     this.redis.on('end', this.listeners.end)
+
+    if (!this.options.redis) { await this.redis.select(this.options.database) }
+    await connectionTest()
   }
 
   async getKeys (match, keysAry = [], cursor = 0) {
@@ -89,17 +79,17 @@ class Connection extends EventEmitter {
   }
 
   end () {
-    this.connected = false
-
     Object.keys(this.listeners).forEach((eventName) => {
       this.redis.removeListener(eventName, this.listeners[eventName])
     })
 
     // Only disconnect if we established the redis connection on our own.
-    if (!this.options.redis) {
+    if (!this.options.redis && this.connected) {
       if (typeof this.redis.disconnect === 'function') { this.redis.disconnect() }
       if (typeof this.redis.quit === 'function') { this.redis.quit() }
     }
+
+    this.connected = false
   }
 
   key () {

--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -51,7 +51,9 @@ class Scheduler extends EventEmitter {
     clearTimeout(this.timer)
 
     if (this.processing === false) {
-      if (this.connection.connected === true || this.connection.connected === undefined || this.connection.connected === null) {
+      if (this.connection && (
+        this.connection.connected === true || this.connection.connected === undefined || this.connection.connected === null)
+      ) {
         try {
           await this.releaseMasterLock()
         } catch (error) {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -75,7 +75,9 @@ class Worker extends EventEmitter {
       return this.end()
     }
 
-    if (this.connection.connected === true || this.connection.connected === undefined || this.connection.connected === null) {
+    if (this.connection && (
+      this.connection.connected === true || this.connection.connected === undefined || this.connection.connected === null)
+    ) {
       clearInterval(this.pingTimer)
       await this.untrack()
     }


### PR DESCRIPTION
At attempt to solve https://github.com/taskrabbit/node-resque/issues/293

This PR makes `connection.connect` (and therefore `worker.connect` and `scheduler.connect`) awaitable until we are really sure that we can read and write to redis.  

We rely on the fact that both node-resid and ioredis will buffer and retry redis commands until they either succeed, timeout, or fail. This allows us to skip the `on('connected')` event and simply wait until we can read data from redis 